### PR TITLE
update to support configuration of a non-local Ollama endpoint.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 api_key.txt
 test_functions.py
 venv/
+.venv/

--- a/attack_tree.py
+++ b/attack_tree.py
@@ -132,9 +132,9 @@ IMPORTANT: Round brackets are special characters in Mermaid syntax. If you want 
     return attack_tree_code
 
 # Function to get attack tree from Ollama hosted LLM.
-def get_attack_tree_ollama(ollama_model, prompt):
+def get_attack_tree_ollama(ollama_endpoint, ollama_model, prompt):
     
-    url = "http://localhost:11434/api/chat"
+    url = ollama_endpoint + "/chat"
 
     data = {
         "model": ollama_model,

--- a/dread.py
+++ b/dread.py
@@ -184,8 +184,8 @@ def get_dread_assessment_mistral(mistral_api_key, mistral_model, prompt):
     return dread_assessment
 
 # Function to get DREAD risk assessment from Ollama hosted LLM.
-def get_dread_assessment_ollama(ollama_model, prompt):
-    url = "http://localhost:11434/api/chat"
+def get_dread_assessment_ollama(ollama_endpoint, ollama_model, prompt):
+    url = ollama_endpoint + "/chat"
     max_retries = 3
     retry_delay = 2  # seconds
 

--- a/main.py
+++ b/main.py
@@ -176,6 +176,10 @@ def load_env_variables():
     if mistral_api_key:
         st.session_state['mistral_api_key'] = mistral_api_key
 
+    ollama_endpoint = os.getenv('OLLAMA_ENDPOINT')
+    if ollama_endpoint:
+        st.session_state['ollama_endpoint'] = ollama_endpoint
+
 # Call this function at the start of your app
 load_env_variables()
 
@@ -323,9 +327,25 @@ with st.sidebar:
         )
 
     if model_provider == "Ollama":
-        # Make a request to the Ollama API to get the list of available models
+        st.markdown(
+        """
+    1. Enter the Ollama endpoint to query (should end in /api, ex http://localhost:11434/api)
+    2. Provide details of the application that you would like to threat model  📝
+    3. Generate a threat list, attack tree and/or mitigating controls for your application 🚀
+    """
+
+    )
+        ollama_endpoint = st.text_input(
+            "Enter your Ollama Endpoint:",
+            value=st.session_state.get('ollama_endpoint', ''),
+            help="This is usually a URL which includes the hostname of the system running your model: http://<hostname>:11434/api.",
+        )
+        if ollama_endpoint:
+            st.session_state['ollama_endpoint'] = ollama_endpoint
+
+
         try:
-            response = requests.get("http://localhost:11434/api/tags")
+            response = requests.get(ollama_endpoint +"/tags")
             response.raise_for_status() # Raise an exception for 4xx/5xx status codes
         except requests.exceptions.RequestException as e:
             st.error("Ollama endpoint not found, please select a different model provider.")
@@ -561,7 +581,7 @@ understanding possible vulnerabilities and attack vectors. Use this tab to gener
                     elif model_provider == "Mistral API":
                         model_output = get_threat_model_mistral(mistral_api_key, mistral_model, threat_model_prompt)
                     elif model_provider == "Ollama":
-                        model_output = get_threat_model_ollama(ollama_model, threat_model_prompt)
+                        model_output = get_threat_model_ollama(ollama_endpoint, ollama_model, threat_model_prompt)
 
                     # Access the threat model and improvement suggestions from the parsed content
                     threat_model = model_output.get("threat_model", [])
@@ -636,7 +656,7 @@ vulnerabilities and prioritising mitigation efforts.
                     elif model_provider == "Mistral API":
                         mermaid_code = get_attack_tree_mistral(mistral_api_key, mistral_model, attack_tree_prompt)
                     elif model_provider == "Ollama":
-                        mermaid_code = get_attack_tree_ollama(ollama_model, attack_tree_prompt)
+                        mermaid_code = get_attack_tree_ollama(ollama_endpoint, ollama_model, attack_tree_prompt)
 
                     # Display the generated attack tree code
                     st.write("Attack Tree Code:")
@@ -716,7 +736,7 @@ the security posture of the application and protect against potential attacks.
                         elif model_provider == "Mistral API":
                             mitigations_markdown = get_mitigations_mistral(mistral_api_key, mistral_model, mitigations_prompt)
                         elif model_provider == "Ollama":
-                            mitigations_markdown = get_mitigations_ollama(ollama_model, mitigations_prompt)
+                            mitigations_markdown = get_mitigations_ollama(ollama_endpoint, ollama_model, mitigations_prompt)
 
                         # Display the suggested mitigations in Markdown
                         st.markdown(mitigations_markdown)
@@ -776,7 +796,7 @@ focusing on the most critical threats first. Use this tab to perform a DREAD ris
                         elif model_provider == "Mistral API":
                             dread_assessment = get_dread_assessment_mistral(mistral_api_key, mistral_model, dread_assessment_prompt)
                         elif model_provider == "Ollama":
-                            dread_assessment = get_dread_assessment_ollama(ollama_model, dread_assessment_prompt)
+                            dread_assessment = get_dread_assessment_ollama(ollama_endpoint, ollama_model, dread_assessment_prompt)
                         # Save the DREAD assessment to the session state for later use in test cases
                         st.session_state['dread_assessment'] = dread_assessment
                         break  # Exit the loop if successful
@@ -841,7 +861,7 @@ scenarios.
                         elif model_provider == "Mistral API":
                             test_cases_markdown = get_test_cases_mistral(mistral_api_key, mistral_model, test_cases_prompt)
                         elif model_provider == "Ollama":
-                            test_cases_markdown = get_test_cases_ollama(ollama_model, test_cases_prompt)
+                            test_cases_markdown = get_test_cases_ollama(ollama_endpoint, ollama_model, test_cases_prompt)
 
                         # Display the suggested mitigations in Markdown
                         st.markdown(test_cases_markdown)

--- a/mitigations.py
+++ b/mitigations.py
@@ -100,9 +100,9 @@ def get_mitigations_mistral(mistral_api_key, mistral_model, prompt):
     return mitigations
 
 # Function to get mitigations from Ollama hosted LLM.
-def get_mitigations_ollama(ollama_model, prompt):
+def get_mitigations_ollama(ollama_endpoint, ollama_model, prompt):
     
-    url = "http://localhost:11434/api/chat"
+    url = ollama_endpoint + "/chat"
 
     data = {
         "model": ollama_model,

--- a/test_cases.py
+++ b/test_cases.py
@@ -99,9 +99,9 @@ def get_test_cases_mistral(mistral_api_key, mistral_model, prompt):
     return test_cases
 
 # Function to get test cases from Ollama hosted LLM.
-def get_test_cases_ollama(ollama_model, prompt):
+def get_test_cases_ollama(ollama_endpoint, ollama_model, prompt):
     
-    url = "http://localhost:11434/api/chat"
+    url = ollama_endpoint + "/chat"
 
     data = {
         "model": ollama_model,

--- a/threat_model.py
+++ b/threat_model.py
@@ -220,9 +220,9 @@ def get_threat_model_mistral(mistral_api_key, mistral_model, prompt):
     return response_content
 
 # Function to get threat model from Ollama hosted LLM.
-def get_threat_model_ollama(ollama_model, prompt):
+def get_threat_model_ollama(ollama_endpoint, ollama_model, prompt):
 
-    url = "http://localhost:11434/api/generate"
+    url = ollama_endpoint + "/generate"
 
     data = {
         "model": ollama_model,


### PR DESCRIPTION
This PR implements functionality to specify remote Ollama endpoints. Ollama doesn't currently support much in the way of authentication, so this goes straight to the system. Only good for internal use. 