### PR TITLE
Minor snyk version bumps following git provider refactoring for Azure DevOps support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ requests>=2.32.2 # not directly required, pinned by Snyk to avoid a vulnerabilit
 urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability
 anyio>=4.4.0 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+h11>=0.16.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
abstracts git providers into 

providers/github_provider.py
providers/azure_devops_provider.py

and some minor version bumps to avoid snyk warnings on upstream merge.