### PR TITLE
Add timeout variable to ollama config and requests

### DIFF
--- a/attack_tree.py
+++ b/attack_tree.py
@@ -246,7 +246,7 @@ def get_attack_tree_mistral(mistral_api_key, mistral_model, prompt):
         return extract_mermaid_code(response.choices[0].message.content)
 
 # Function to get attack tree from Ollama hosted LLM.
-def get_attack_tree_ollama(ollama_endpoint, ollama_model, prompt):
+def get_attack_tree_ollama(ollama_endpoint, ollama_model, ollama_timeout, prompt):
     """
     Get attack tree from Ollama hosted LLM.
     
@@ -278,7 +278,7 @@ def get_attack_tree_ollama(ollama_endpoint, ollama_model, prompt):
     }
 
     try:
-        response = requests.post(url, json=data, timeout=60)  # Add timeout
+        response = requests.post(url, json=data, timeout=ollama_timeout)  # Add timeout
         response.raise_for_status()  # Raise exception for bad status codes
         outer_json = response.json()
         

--- a/dread.py
+++ b/dread.py
@@ -271,7 +271,7 @@ def get_dread_assessment_mistral(mistral_api_key, mistral_model, prompt):
     return dread_assessment
 
 # Function to get DREAD risk assessment from Ollama hosted LLM.
-def get_dread_assessment_ollama(ollama_endpoint, ollama_model, prompt):
+def get_dread_assessment_ollama(ollama_endpoint, ollama_model, ollama_timeout, prompt):
     """
     Get DREAD risk assessment from Ollama hosted LLM.
     
@@ -329,7 +329,7 @@ Please provide your response in JSON format with the following structure:
 
     for attempt in range(max_retries):
         try:
-            response = requests.post(url, json=data, timeout=60)  # Add timeout
+            response = requests.post(url, json=data, timeout=ollama_timeout)  # Add timeout
             response.raise_for_status()  # Raise exception for bad status codes
             outer_json = response.json()
             

--- a/main.py
+++ b/main.py
@@ -822,6 +822,16 @@ with st.sidebar:
             help="Select a model from your local Ollama instance. If you don't see any models, make sure Ollama is running and has models installed."
         )
 
+        # Add timeout configuration
+        ollama_timeout = st.number_input(
+            "Ollama request timeout (seconds):",
+            min_value=60,
+            max_value=600,
+            value=60,
+            step=20,
+            help="Set the timeout for requests to your Ollama instance. Increase this if you experience timeouts with larger models.",
+        )
+
     if model_provider == "LM Studio Server":
         st.markdown(
         """
@@ -1226,7 +1236,7 @@ understanding possible vulnerabilities and attack vectors. Use this tab to gener
                     elif model_provider == "Mistral API":
                         model_output = get_threat_model_mistral(mistral_api_key, mistral_model, threat_model_prompt)
                     elif model_provider == "Ollama":
-                        model_output = get_threat_model_ollama(st.session_state['ollama_endpoint'], selected_model, threat_model_prompt)
+                        model_output = get_threat_model_ollama(st.session_state['ollama_endpoint'], selected_model, ollama_timeout, threat_model_prompt)
                     elif model_provider == "Anthropic API":
                         model_output = get_threat_model_anthropic(anthropic_api_key, anthropic_model, threat_model_prompt)
                         # Check if we got a fallback response
@@ -1326,7 +1336,7 @@ vulnerabilities and prioritising mitigation efforts.
                     elif model_provider == "Mistral API":
                         mermaid_code = get_attack_tree_mistral(mistral_api_key, mistral_model, attack_tree_prompt)
                     elif model_provider == "Ollama":
-                        mermaid_code = get_attack_tree_ollama(st.session_state['ollama_endpoint'], selected_model, attack_tree_prompt)
+                        mermaid_code = get_attack_tree_ollama(st.session_state['ollama_endpoint'], selected_model, ollama_timeout, attack_tree_prompt)
                     elif model_provider == "Anthropic API":
                         mermaid_code = get_attack_tree_anthropic(anthropic_api_key, anthropic_model, attack_tree_prompt)
                     elif model_provider == "LM Studio Server":
@@ -1425,7 +1435,7 @@ the security posture of the application and protect against potential attacks.
                         elif model_provider == "Mistral API":
                             mitigations_markdown = get_mitigations_mistral(mistral_api_key, mistral_model, mitigations_prompt)
                         elif model_provider == "Ollama":
-                            mitigations_markdown = get_mitigations_ollama(st.session_state['ollama_endpoint'], selected_model, mitigations_prompt)
+                            mitigations_markdown = get_mitigations_ollama(st.session_state['ollama_endpoint'], selected_model, ollama_timeout, mitigations_prompt)
                         elif model_provider == "Anthropic API":
                             mitigations_markdown = get_mitigations_anthropic(anthropic_api_key, anthropic_model, mitigations_prompt)
                         elif model_provider == "LM Studio Server":
@@ -1507,7 +1517,7 @@ focusing on the most critical threats first. Use this tab to perform a DREAD ris
                         elif model_provider == "Mistral API":
                             dread_assessment = get_dread_assessment_mistral(mistral_api_key, mistral_model, dread_assessment_prompt)
                         elif model_provider == "Ollama":
-                            dread_assessment = get_dread_assessment_ollama(st.session_state['ollama_endpoint'], selected_model, dread_assessment_prompt)
+                            dread_assessment = get_dread_assessment_ollama(st.session_state['ollama_endpoint'], selected_model, ollama_timeout, dread_assessment_prompt)
                         elif model_provider == "Anthropic API":
                             dread_assessment = get_dread_assessment_anthropic(anthropic_api_key, anthropic_model, dread_assessment_prompt)
                         elif model_provider == "LM Studio Server":
@@ -1604,7 +1614,7 @@ scenarios.
                         elif model_provider == "Mistral API":
                             test_cases_markdown = get_test_cases_mistral(mistral_api_key, mistral_model, test_cases_prompt)
                         elif model_provider == "Ollama":
-                            test_cases_markdown = get_test_cases_ollama(st.session_state['ollama_endpoint'], selected_model, test_cases_prompt)
+                            test_cases_markdown = get_test_cases_ollama(st.session_state['ollama_endpoint'], selected_model, ollama_timeout, test_cases_prompt)
                         elif model_provider == "Anthropic API":
                             test_cases_markdown = get_test_cases_anthropic(anthropic_api_key, anthropic_model, test_cases_prompt)
                         elif model_provider == "LM Studio Server":

--- a/mitigations.py
+++ b/mitigations.py
@@ -170,7 +170,7 @@ def get_mitigations_mistral(mistral_api_key, mistral_model, prompt):
     return mitigations
 
 # Function to get mitigations from Ollama hosted LLM.
-def get_mitigations_ollama(ollama_endpoint, ollama_model, prompt):
+def get_mitigations_ollama(ollama_endpoint, ollama_model, ollama_timeout, prompt):
     """
     Get mitigations from Ollama hosted LLM.
     
@@ -209,7 +209,7 @@ Please provide your response in markdown format with appropriate headings and bu
     }
 
     try:
-        response = requests.post(url, json=data, timeout=60)  # Add timeout
+        response = requests.post(url, json=data, timeout=ollama_timeout)  # Add timeout
         response.raise_for_status()  # Raise exception for bad status codes
         outer_json = response.json()
         

--- a/test_cases.py
+++ b/test_cases.py
@@ -193,7 +193,7 @@ def get_test_cases_mistral(mistral_api_key, mistral_model, prompt):
     return test_cases
 
 # Function to get test cases from Ollama hosted LLM.
-def get_test_cases_ollama(ollama_endpoint, ollama_model, prompt):
+def get_test_cases_ollama(ollama_endpoint, ollama_model, ollama_timeout, prompt):
     """
     Get test cases from Ollama hosted LLM.
     
@@ -237,7 +237,7 @@ Please provide your response in markdown format with appropriate headings and bu
     }
 
     try:
-        response = requests.post(url, json=data, timeout=60)  # Add timeout
+        response = requests.post(url, json=data, timeout=ollama_timeout)  # Add timeout
         response.raise_for_status()  # Raise exception for bad status codes
         outer_json = response.json()
         

--- a/threat_model.py
+++ b/threat_model.py
@@ -422,13 +422,14 @@ def get_threat_model_mistral(mistral_api_key, mistral_model, prompt):
     return response_content
 
 # Function to get threat model from Ollama hosted LLM.
-def get_threat_model_ollama(ollama_endpoint, ollama_model, prompt):
+def get_threat_model_ollama(ollama_endpoint, ollama_model, ollama_timeout, prompt):
     """
     Get threat model from Ollama hosted LLM.
     
     Args:
         ollama_endpoint (str): The URL of the Ollama endpoint (e.g., 'http://localhost:11434')
         ollama_model (str): The name of the model to use
+        ollama_timeout (int): Timeout for the request in seconds
         prompt (str): The prompt to send to the model
         
     Returns:
@@ -454,7 +455,7 @@ def get_threat_model_ollama(ollama_endpoint, ollama_model, prompt):
     }
 
     try:
-        response = requests.post(url, json=data, timeout=60)  # Add timeout
+        response = requests.post(url, json=data, timeout=ollama_timeout)  # Add timeout
         response.raise_for_status()  # Raise exception for bad status codes
         outer_json = response.json()
         


### PR DESCRIPTION
The current timeout for ollama model requests is set at 60 seconds. For some models and hardware configurations this results in a timeout error. This fix allows the user to select a timeout between 60 and 600 seconds.