### PR TITLE
fix: update mistralai imports for v2 SDK

### DIFF
--- a/attack_tree.py
+++ b/attack_tree.py
@@ -6,7 +6,7 @@ import streamlit as st
 from anthropic import Anthropic
 from google import genai as google_genai
 from groq import Groq
-from mistralai import Mistral
+from mistralai.client import Mistral
 from openai import OpenAI
 
 from utils import create_reasoning_system_prompt, extract_mermaid_code, process_groq_response

--- a/dread.py
+++ b/dread.py
@@ -7,7 +7,7 @@ import streamlit as st
 from anthropic import Anthropic
 from google import genai as google_genai
 from groq import Groq
-from mistralai import Mistral
+from mistralai.client import Mistral
 from openai import OpenAI
 
 from utils import create_reasoning_system_prompt, process_groq_response

--- a/mitigations.py
+++ b/mitigations.py
@@ -3,7 +3,7 @@ import streamlit as st
 from anthropic import Anthropic
 from google import genai as google_genai
 from groq import Groq
-from mistralai import Mistral
+from mistralai.client import Mistral
 from openai import OpenAI
 
 from utils import create_reasoning_system_prompt, process_groq_response

--- a/test_cases.py
+++ b/test_cases.py
@@ -3,7 +3,7 @@ import streamlit as st
 from anthropic import Anthropic
 from google import genai as google_genai
 from groq import Groq
-from mistralai import Mistral
+from mistralai.client import Mistral
 from openai import OpenAI
 
 from utils import create_reasoning_system_prompt, process_groq_response

--- a/threat_model.py
+++ b/threat_model.py
@@ -7,7 +7,7 @@ import streamlit as st
 from anthropic import Anthropic
 from google import genai as google_genai
 from groq import Groq
-from mistralai import Mistral
+from mistralai.client import Mistral
 from openai import OpenAI
 
 from utils import create_reasoning_system_prompt, process_groq_response


### PR DESCRIPTION
## Summary
- mistralai v2 dropped the top-level `Mistral` re-export; the class now lives at `mistralai.client.Mistral`. With `mistralai>=2.4.5` pinned in `requirements.txt`, fresh installs (Streamlit Cloud) failed at app start with `ImportError: ... from mistralai import Mistral` (traceback originates in `attack_tree.py:9`, hit during `main.py` import).
- Updates the import in all 5 affected modules: `attack_tree.py`, `dread.py`, `mitigations.py`, `test_cases.py`, `threat_model.py`.
- No call-site changes: verified against the v2.4.5 wheel that `Mistral(api_key=...)` constructor and `client.chat.complete(model=..., response_format=..., messages=...)` are unchanged.

## Test plan
- [ ] Redeploy on Streamlit Cloud and confirm the app loads (no ImportError on `main.py`).
- [ ] Smoke-test a Mistral-backed threat model run (uses `client.chat.complete` with `response_format={"type": "json_object"}`).
- [ ] Smoke-test attack tree, DREAD, mitigations, and test-cases tabs with a Mistral model selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)