### PR TITLE
feat: Add HTML report companion for /analyze and /quick

### DIFF
--- a/stride_gpt/agent/html_report.py
+++ b/stride_gpt/agent/html_report.py
@@ -17,22 +17,30 @@ from typing import Any
 from stride_gpt.agent.report import render_json
 from stride_gpt.core.schemas import AnalysisReport
 
-# STRIDE category → Tailwind badge classes. The six categories carry distinct
-# hues because category is the dominant visual signal in a threat model.
+# STRIDE category → Tailwind badge classes. Six categories carry distinct
+# hues because category is the dominant visual signal, but each pairs a -50
+# fill with a matching ring so chips read as categorized tags rather than
+# highlighter marks against the slate chrome.
 _STRIDE_BADGE_CLASSES: dict[str, str] = {
-    "Spoofing": "bg-indigo-100 text-indigo-800",
-    "Tampering": "bg-amber-100 text-amber-800",
-    "Repudiation": "bg-slate-200 text-slate-800",
-    "Information Disclosure": "bg-rose-100 text-rose-800",
-    "Denial of Service": "bg-orange-100 text-orange-800",
-    "Elevation of Privilege": "bg-red-100 text-red-800",
+    "Spoofing": "bg-indigo-50 text-indigo-800 ring-indigo-200",
+    "Tampering": "bg-amber-50 text-amber-800 ring-amber-200",
+    "Repudiation": "bg-slate-100 text-slate-800 ring-slate-300",
+    "Information Disclosure": "bg-rose-50 text-rose-800 ring-rose-200",
+    "Denial of Service": "bg-orange-50 text-orange-800 ring-orange-200",
+    "Elevation of Privilege": "bg-red-50 text-red-800 ring-red-200",
 }
-_DEFAULT_BADGE = "bg-slate-100 text-slate-800"
-_BADGE_BASE = "inline-flex items-center rounded-full px-3 py-1 text-xs font-medium"
-_PILL_BASE = (
-    "inline-flex items-center rounded-full border border-slate-300 "
-    "px-2.5 py-0.5 text-xs font-medium text-slate-700"
+_DEFAULT_BADGE = "bg-slate-50 text-slate-800 ring-slate-200"
+_BADGE_BASE = (
+    "inline-flex items-center rounded-full px-3 py-1 text-xs font-medium "
+    "ring-1 ring-inset"
 )
+_PILL_BASE = (
+    "inline-flex items-center rounded-full ring-1 ring-inset ring-slate-300 "
+    "px-2.5 py-0.5 text-xs font-mono text-slate-700"
+)
+# Small uppercase captions inside cards — Scenario, Potential impact, etc.
+# Mono ties them to the CLI aesthetic without leaning hard on a "terminal" theme.
+_CAPTION = "text-[11px] font-mono uppercase tracking-wider text-slate-500"
 
 
 def render_html(report: AnalysisReport) -> str:
@@ -97,7 +105,7 @@ def _scaffold(*, target_name: str, body: str) -> str:
     <title>{title}</title>
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
-  <body class="bg-stone-50 text-slate-900 font-sans">
+  <body class="bg-slate-50 text-slate-900 font-sans">
     <main class="max-w-5xl mx-auto px-6 py-12 space-y-12">
 {body}
     </main>
@@ -117,8 +125,8 @@ def _render_header(
 ) -> str:
     model_line = _format_model_line(metadata)
     chip = (
-        "inline-flex items-center rounded-full bg-white border border-slate-200 "
-        "px-3 py-1 text-xs font-medium text-slate-700"
+        "inline-flex items-center rounded-full bg-white ring-1 ring-inset ring-slate-200 "
+        "px-3 py-1 text-xs font-mono text-slate-700"
     )
 
     summary_chips = [
@@ -133,12 +141,6 @@ def _render_header(
             f'<span class="{chip}">{cross_cutting_count} cross-cutting</span>'
         )
 
-    legend_items: list[str] = []
-    for stride_type, badge_classes in _STRIDE_BADGE_CLASSES.items():
-        legend_items.append(
-            f'<span class="{_BADGE_BASE} {badge_classes}">{html.escape(stride_type)}</span>'
-        )
-
     meta_line_parts: list[str] = []
     if generated_at:
         meta_line_parts.append(f"Generated {html.escape(generated_at)}")
@@ -147,17 +149,20 @@ def _render_header(
     meta_line = " · ".join(meta_line_parts)
 
     return f"""      <header class="border-b border-slate-200 pb-8 space-y-4">
-        <p class="text-xs uppercase tracking-wider text-slate-500">STRIDE Threat Model</p>
-        <h1 class="font-serif text-4xl tracking-tight text-slate-900">{html.escape(target_name)}</h1>
+        <p class="font-mono text-xs tracking-tight text-slate-500">
+          <span class="text-slate-400">&rsaquo;</span>
+          <span class="text-slate-700">stride-gpt</span>
+          <span class="text-slate-400">threat-model</span>
+        </p>
+        <h1 class="text-3xl font-semibold tracking-tight text-slate-900">{html.escape(target_name)}</h1>
         <p class="text-sm text-slate-600">{meta_line}</p>
         <div class="flex flex-wrap gap-2 pt-2">{"".join(summary_chips)}</div>
-        <div class="flex flex-wrap gap-2 pt-2">{"".join(legend_items)}</div>
       </header>"""
 
 
 def _render_overview(overview: str) -> str:
     return f"""      <section id="overview" class="space-y-3">
-        <h2 class="text-xs uppercase tracking-wider text-slate-500">Overview</h2>
+        <h2 class="{_CAPTION}">Overview</h2>
         <p class="text-base leading-relaxed text-slate-800">{html.escape(overview)}</p>
       </section>"""
 
@@ -174,8 +179,8 @@ def _render_footer(metadata: dict[str, Any]) -> str:
     if model_line:
         bits.append(model_line)
     line = " · ".join(bits)
-    return f"""      <footer class="border-t border-slate-200 pt-6 text-xs text-slate-500">
-        Generated by STRIDE-GPT{(" · " + html.escape(line)) if line else ""}
+    return f"""      <footer class="border-t border-slate-200 pt-6 font-mono text-xs text-slate-500">
+        <span class="text-slate-400">&rsaquo;</span> generated by stride-gpt{(" · " + html.escape(line)) if line else ""}
       </footer>"""
 
 
@@ -193,7 +198,7 @@ def _render_subsystem(sub: dict[str, Any]) -> str:
 
     parts: list[str] = []
     parts.append(f"""        <header class="space-y-1">
-          <h2 class="font-serif text-2xl tracking-tight text-slate-900">{html.escape(name)}</h2>""")
+          <h2 class="text-xl font-semibold tracking-tight text-slate-900">{html.escape(name)}</h2>""")
     if description:
         parts.append(
             f'          <p class="text-sm text-slate-600">{html.escape(description)}</p>'
@@ -226,7 +231,7 @@ def _render_cross_cutting(threats: list[dict[str, Any]]) -> str:
     cards = "\n".join(_render_threat_card(t, cross_cutting=True) for t in threats)
     return f"""      <section id="cross-cutting" class="space-y-5">
         <header class="space-y-1">
-          <h2 class="font-serif text-2xl tracking-tight text-slate-900">Cross-cutting threats</h2>
+          <h2 class="text-xl font-semibold tracking-tight text-slate-900">Cross-cutting threats</h2>
           <p class="text-sm text-slate-600">Issues that span multiple subsystems.</p>
         </header>
         <div class="space-y-4">
@@ -241,7 +246,7 @@ def _render_files_analyzed(files: list[str]) -> str:
         for f in files
     )
     return f"""        <div>
-          <h3 class="text-xs uppercase tracking-wider text-slate-500 mb-2">Files analyzed</h3>
+          <h3 class="{_CAPTION} mb-2">Files analyzed</h3>
           <ul class="space-y-1">
 {items}
           </ul>
@@ -253,7 +258,7 @@ def _render_recommendations(suggestions: list[str]) -> str:
         f'            <li>{html.escape(str(s))}</li>' for s in suggestions
     )
     return f"""        <div class="rounded-lg border border-slate-200 bg-white p-5">
-          <h3 class="text-xs uppercase tracking-wider text-slate-500 mb-3">Recommendations</h3>
+          <h3 class="{_CAPTION} mb-3">Recommendations</h3>
           <ul class="list-disc pl-5 space-y-1 text-sm text-slate-800">
 {items}
           </ul>
@@ -312,7 +317,7 @@ def _render_threat_card(threat: dict[str, Any], *, cross_cutting: bool) -> str:
 
 def _dl_row(label: str, value_html: str) -> str:
     return f"""              <div>
-                <dt class="text-xs uppercase tracking-wider text-slate-500">{label}</dt>
+                <dt class="{_CAPTION}">{label}</dt>
                 <dd class="text-sm leading-relaxed text-slate-800">{value_html}</dd>
               </div>"""
 

--- a/stride_gpt/agent/html_report.py
+++ b/stride_gpt/agent/html_report.py
@@ -1,0 +1,355 @@
+"""HTML report renderer — single-file, Tailwind-styled view of a STRIDE report.
+
+Output is a self-contained HTML document. The only external dependency is
+the Tailwind CDN; there is no JavaScript and no app code. Designed as a
+human-readable companion to the JSON report — STRIDE category is the primary
+visual signal, every threat gets a card, and optional OWASP / Insider lenses
+surface as outline pills when present.
+"""
+
+from __future__ import annotations
+
+import html
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from stride_gpt.agent.report import render_json
+from stride_gpt.core.schemas import AnalysisReport
+
+# STRIDE category → Tailwind badge classes. The six categories carry distinct
+# hues because category is the dominant visual signal in a threat model.
+_STRIDE_BADGE_CLASSES: dict[str, str] = {
+    "Spoofing": "bg-indigo-100 text-indigo-800",
+    "Tampering": "bg-amber-100 text-amber-800",
+    "Repudiation": "bg-slate-200 text-slate-800",
+    "Information Disclosure": "bg-rose-100 text-rose-800",
+    "Denial of Service": "bg-orange-100 text-orange-800",
+    "Elevation of Privilege": "bg-red-100 text-red-800",
+}
+_DEFAULT_BADGE = "bg-slate-100 text-slate-800"
+_BADGE_BASE = "inline-flex items-center rounded-full px-3 py-1 text-xs font-medium"
+_PILL_BASE = (
+    "inline-flex items-center rounded-full border border-slate-300 "
+    "px-2.5 py-0.5 text-xs font-medium text-slate-700"
+)
+
+
+def render_html(report: AnalysisReport) -> str:
+    """Render an in-memory AnalysisReport as a self-contained HTML document."""
+    return render_html_from_json(render_json(report))
+
+
+def render_html_from_json(data: dict[str, Any]) -> str:
+    """Render a saved JSON report (the disk format) as HTML.
+
+    The two entry points share this implementation so the live `/analyze`
+    output and the `/reports` replay path produce byte-identical HTML.
+    """
+    target = data.get("target") or ""
+    target_name = Path(target).name or target or "(unknown target)"
+    generated_at = _format_generated_at(data.get("generated_at", ""))
+    overview = (data.get("overview") or "").strip()
+    subsystems = data.get("subsystems") or []
+    cross_cutting = data.get("cross_cutting_threats") or []
+    metadata = data.get("metadata") or {}
+
+    total_threats = sum(len(s.get("threats") or []) for s in subsystems)
+    total_threats += len(cross_cutting)
+
+    parts: list[str] = []
+    parts.append(_render_header(
+        target_name=target_name,
+        generated_at=generated_at,
+        metadata=metadata,
+        total_threats=total_threats,
+        subsystem_count=len(subsystems),
+        cross_cutting_count=len(cross_cutting),
+    ))
+
+    if overview:
+        parts.append(_render_overview(overview))
+
+    for sub in subsystems:
+        parts.append(_render_subsystem(sub))
+
+    if cross_cutting:
+        parts.append(_render_cross_cutting(cross_cutting))
+
+    parts.append(_render_footer(metadata))
+
+    body = "\n".join(parts)
+    return _scaffold(target_name=target_name, body=body)
+
+
+# ---------------------------------------------------------------------------
+# Scaffold + page chrome
+# ---------------------------------------------------------------------------
+
+
+def _scaffold(*, target_name: str, body: str) -> str:
+    title = html.escape(f"STRIDE Threat Model — {target_name}")
+    return f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-stone-50 text-slate-900 font-sans">
+    <main class="max-w-5xl mx-auto px-6 py-12 space-y-12">
+{body}
+    </main>
+  </body>
+</html>
+"""
+
+
+def _render_header(
+    *,
+    target_name: str,
+    generated_at: str,
+    metadata: dict[str, Any],
+    total_threats: int,
+    subsystem_count: int,
+    cross_cutting_count: int,
+) -> str:
+    model_line = _format_model_line(metadata)
+    chip = (
+        "inline-flex items-center rounded-full bg-white border border-slate-200 "
+        "px-3 py-1 text-xs font-medium text-slate-700"
+    )
+
+    summary_chips = [
+        f'<span class="{chip}">{total_threats} threats</span>',
+    ]
+    # /quick reports collapse to one synthetic "Application" subsystem; showing
+    # "1 subsystem" there would be misleading, so suppress when ≤1.
+    if subsystem_count > 1:
+        summary_chips.append(f'<span class="{chip}">{subsystem_count} subsystems</span>')
+    if cross_cutting_count:
+        summary_chips.append(
+            f'<span class="{chip}">{cross_cutting_count} cross-cutting</span>'
+        )
+
+    legend_items: list[str] = []
+    for stride_type, badge_classes in _STRIDE_BADGE_CLASSES.items():
+        legend_items.append(
+            f'<span class="{_BADGE_BASE} {badge_classes}">{html.escape(stride_type)}</span>'
+        )
+
+    meta_line_parts: list[str] = []
+    if generated_at:
+        meta_line_parts.append(f"Generated {html.escape(generated_at)}")
+    if model_line:
+        meta_line_parts.append(html.escape(model_line))
+    meta_line = " · ".join(meta_line_parts)
+
+    return f"""      <header class="border-b border-slate-200 pb-8 space-y-4">
+        <p class="text-xs uppercase tracking-wider text-slate-500">STRIDE Threat Model</p>
+        <h1 class="font-serif text-4xl tracking-tight text-slate-900">{html.escape(target_name)}</h1>
+        <p class="text-sm text-slate-600">{meta_line}</p>
+        <div class="flex flex-wrap gap-2 pt-2">{"".join(summary_chips)}</div>
+        <div class="flex flex-wrap gap-2 pt-2">{"".join(legend_items)}</div>
+      </header>"""
+
+
+def _render_overview(overview: str) -> str:
+    return f"""      <section id="overview" class="space-y-3">
+        <h2 class="text-xs uppercase tracking-wider text-slate-500">Overview</h2>
+        <p class="text-base leading-relaxed text-slate-800">{html.escape(overview)}</p>
+      </section>"""
+
+
+def _render_footer(metadata: dict[str, Any]) -> str:
+    bits: list[str] = []
+    llm_calls = metadata.get("llm_calls")
+    tool_calls = metadata.get("tool_calls")
+    if llm_calls is not None:
+        bits.append(f"{llm_calls} LLM calls")
+    if tool_calls is not None:
+        bits.append(f"{tool_calls} tool calls")
+    model_line = _format_model_line(metadata)
+    if model_line:
+        bits.append(model_line)
+    line = " · ".join(bits)
+    return f"""      <footer class="border-t border-slate-200 pt-6 text-xs text-slate-500">
+        Generated by STRIDE-GPT{(" · " + html.escape(line)) if line else ""}
+      </footer>"""
+
+
+# ---------------------------------------------------------------------------
+# Sections
+# ---------------------------------------------------------------------------
+
+
+def _render_subsystem(sub: dict[str, Any]) -> str:
+    name = sub.get("name") or "(unnamed)"
+    description = (sub.get("description") or "").strip()
+    files = sub.get("files_analyzed") or []
+    threats = sub.get("threats") or []
+    suggestions = sub.get("improvement_suggestions") or []
+
+    parts: list[str] = []
+    parts.append(f"""        <header class="space-y-1">
+          <h2 class="font-serif text-2xl tracking-tight text-slate-900">{html.escape(name)}</h2>""")
+    if description:
+        parts.append(
+            f'          <p class="text-sm text-slate-600">{html.escape(description)}</p>'
+        )
+    parts.append("        </header>")
+
+    if files:
+        parts.append(_render_files_analyzed(files))
+
+    if threats:
+        cards = "\n".join(_render_threat_card(t, cross_cutting=False) for t in threats)
+        parts.append(f"""        <div class="space-y-4">
+{cards}
+        </div>""")
+    else:
+        parts.append(
+            '        <p class="text-sm italic text-slate-500">No threats identified.</p>'
+        )
+
+    if suggestions:
+        parts.append(_render_recommendations(suggestions))
+
+    body = "\n".join(parts)
+    return f"""      <section class="space-y-5">
+{body}
+      </section>"""
+
+
+def _render_cross_cutting(threats: list[dict[str, Any]]) -> str:
+    cards = "\n".join(_render_threat_card(t, cross_cutting=True) for t in threats)
+    return f"""      <section id="cross-cutting" class="space-y-5">
+        <header class="space-y-1">
+          <h2 class="font-serif text-2xl tracking-tight text-slate-900">Cross-cutting threats</h2>
+          <p class="text-sm text-slate-600">Issues that span multiple subsystems.</p>
+        </header>
+        <div class="space-y-4">
+{cards}
+        </div>
+      </section>"""
+
+
+def _render_files_analyzed(files: list[str]) -> str:
+    items = "\n".join(
+        f'            <li class="font-mono text-xs text-slate-700">{html.escape(f)}</li>'
+        for f in files
+    )
+    return f"""        <div>
+          <h3 class="text-xs uppercase tracking-wider text-slate-500 mb-2">Files analyzed</h3>
+          <ul class="space-y-1">
+{items}
+          </ul>
+        </div>"""
+
+
+def _render_recommendations(suggestions: list[str]) -> str:
+    items = "\n".join(
+        f'            <li>{html.escape(str(s))}</li>' for s in suggestions
+    )
+    return f"""        <div class="rounded-lg border border-slate-200 bg-white p-5">
+          <h3 class="text-xs uppercase tracking-wider text-slate-500 mb-3">Recommendations</h3>
+          <ul class="list-disc pl-5 space-y-1 text-sm text-slate-800">
+{items}
+          </ul>
+        </div>"""
+
+
+# ---------------------------------------------------------------------------
+# Threat card
+# ---------------------------------------------------------------------------
+
+
+def _render_threat_card(threat: dict[str, Any], *, cross_cutting: bool) -> str:
+    threat_type = threat.get("Threat Type") or "Unknown"
+    scenario = str(threat.get("Scenario") or "")
+    impact = str(threat.get("Potential Impact") or "")
+    owasp_llm = threat.get("OWASP_LLM")
+    owasp_asi = threat.get("OWASP_ASI")
+    insider = threat.get("INSIDER_CATEGORY")
+    affected = threat.get("Affected Subsystems") or []
+
+    badge_classes = _STRIDE_BADGE_CLASSES.get(threat_type, _DEFAULT_BADGE)
+
+    badges: list[str] = [
+        f'<span class="{_BADGE_BASE} {badge_classes}">{html.escape(str(threat_type))}</span>'
+    ]
+    if owasp_llm:
+        badges.append(f'<span class="{_PILL_BASE}">OWASP {html.escape(str(owasp_llm))}</span>')
+    if owasp_asi:
+        badges.append(f'<span class="{_PILL_BASE}">ASI {html.escape(str(owasp_asi))}</span>')
+    if insider:
+        badges.append(
+            f'<span class="{_PILL_BASE}">Insider: {html.escape(str(insider))}</span>'
+        )
+
+    rows: list[str] = []
+    if scenario:
+        rows.append(_dl_row("Scenario", html.escape(scenario)))
+    if impact:
+        rows.append(_dl_row("Potential impact", html.escape(impact)))
+    if cross_cutting and affected:
+        pills = "".join(
+            f'<span class="{_PILL_BASE}">{html.escape(str(a))}</span> '
+            for a in affected
+        )
+        rows.append(_dl_row("Affects", f'<div class="flex flex-wrap gap-1">{pills}</div>'))
+
+    badge_row = "".join(b + " " for b in badges)
+    body = "\n".join(rows)
+    return f"""          <article class="rounded-lg border border-slate-200 bg-white p-5 space-y-3">
+            <div class="flex flex-wrap gap-2">{badge_row}</div>
+            <dl class="space-y-3">
+{body}
+            </dl>
+          </article>"""
+
+
+def _dl_row(label: str, value_html: str) -> str:
+    return f"""              <div>
+                <dt class="text-xs uppercase tracking-wider text-slate-500">{label}</dt>
+                <dd class="text-sm leading-relaxed text-slate-800">{value_html}</dd>
+              </div>"""
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_generated_at(raw: str) -> str:
+    """Convert ISO-8601 to a humane 'YYYY-MM-DD HH:MM UTC' form.
+
+    Falls back to the raw string if parsing fails — we never want a report
+    timestamp to break the renderer.
+    """
+    if not raw:
+        return ""
+    try:
+        cleaned = raw.rstrip("Z")
+        dt = datetime.fromisoformat(cleaned)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    except (ValueError, TypeError):
+        return raw
+
+
+def _format_model_line(metadata: dict[str, Any]) -> str:
+    worker = metadata.get("worker_model")
+    worker_provider = metadata.get("worker_provider", "")
+    architect = metadata.get("architect_model")
+    architect_provider = metadata.get("architect_provider", "")
+    if architect:
+        return (
+            f"Architect: {architect_provider}/{architect} · "
+            f"Worker: {worker_provider}/{worker}"
+        )
+    if worker:
+        return f"Model: {worker_provider}/{worker}"
+    return ""

--- a/stride_gpt/agent/html_report.py
+++ b/stride_gpt/agent/html_report.py
@@ -14,7 +14,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from stride_gpt.agent.report import render_json
 from stride_gpt.core.schemas import AnalysisReport
 
 # STRIDE category → Tailwind badge classes. Six categories carry distinct
@@ -44,8 +43,30 @@ _CAPTION = "text-[11px] font-mono uppercase tracking-wider text-slate-500"
 
 
 def render_html(report: AnalysisReport) -> str:
-    """Render an in-memory AnalysisReport as a self-contained HTML document."""
-    return render_html_from_json(render_json(report))
+    """Render an in-memory AnalysisReport as a self-contained HTML document.
+
+    Builds the JSON-shape view inline rather than calling `render_json` from
+    `agent.report` — that would create an import cycle (report.py
+    lazy-imports this module to write the HTML companion).
+    """
+    data: dict[str, Any] = {
+        "version": "1.0",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "target": report.plan.target_path,
+        "overview": report.plan.overall_description,
+        "subsystems": [
+            {
+                "name": f.subsystem,
+                "threats": f.threats,
+                "improvement_suggestions": f.improvement_suggestions,
+                "files_analyzed": f.files_analyzed,
+            }
+            for f in report.findings
+        ],
+        "cross_cutting_threats": report.cross_cutting_threats,
+        "metadata": report.metadata,
+    }
+    return render_html_from_json(data)
 
 
 def render_html_from_json(data: dict[str, Any]) -> str:

--- a/stride_gpt/agent/report.py
+++ b/stride_gpt/agent/report.py
@@ -338,15 +338,20 @@ def save_quick_report(
 def _write_html_companion(json_path: Path, data: dict[str, Any]) -> None:
     """Auto-save an HTML view next to a JSON report.
 
-    Best-effort: if rendering fails we keep the JSON write intact so the user
-    never loses their analysis to a UI bug.
+    Best-effort: a render bug must not lose the JSON write the user just
+    finished waiting for. We catch broadly and surface to stderr so failures
+    are visible without crashing the save path.
     """
     try:
         from stride_gpt.agent.html_report import render_html_from_json
         html_path = json_path.with_suffix(".html")
         html_path.write_text(render_html_from_json(data))
-    except Exception:
-        pass
+    except Exception as exc:  # noqa: BLE001 — see docstring
+        import sys
+        print(
+            f"[stride-gpt] warning: HTML companion failed: {exc}",
+            file=sys.stderr,
+        )
 
 
 def load_report(path: Path) -> dict[str, Any]:

--- a/stride_gpt/agent/report.py
+++ b/stride_gpt/agent/report.py
@@ -266,7 +266,9 @@ def save_report(report: AnalysisReport) -> Path:
     filename = f"{name}_{timestamp}.json"
 
     path = target_dir / filename
-    path.write_text(json.dumps(render_json(report), indent=2) + "\n")
+    rendered = render_json(report)
+    path.write_text(json.dumps(rendered, indent=2) + "\n")
+    _write_html_companion(path, rendered)
     return path
 
 
@@ -329,7 +331,22 @@ def save_quick_report(
 
     path = target_dir / filename
     path.write_text(json.dumps(data, indent=2) + "\n")
+    _write_html_companion(path, data)
     return path
+
+
+def _write_html_companion(json_path: Path, data: dict[str, Any]) -> None:
+    """Auto-save an HTML view next to a JSON report.
+
+    Best-effort: if rendering fails we keep the JSON write intact so the user
+    never loses their analysis to a UI bug.
+    """
+    try:
+        from stride_gpt.agent.html_report import render_html_from_json
+        html_path = json_path.with_suffix(".html")
+        html_path.write_text(render_html_from_json(data))
+    except Exception:
+        pass
 
 
 def load_report(path: Path) -> dict[str, Any]:

--- a/stride_gpt/cli.py
+++ b/stride_gpt/cli.py
@@ -55,15 +55,16 @@ HELP_TEXT = """
 
 [bold]Flags[/bold] (for /analyze, /quick, /reports):
   [cyan]-o, --output[/cyan] <path>    Save report to file
-  [cyan]-f, --format[/cyan] <fmt>     Output format: markdown (default), json, sarif
+  [cyan]-f, --format[/cyan] <fmt>     Output format: markdown (default), json, sarif, html
   [cyan]-y, --yes[/cyan]              Auto-approve the analysis plan
 
 [bold]Examples:[/bold]
   [dim]/analyze .[/dim]                          Analyze current directory
   [dim]/analyze ./my-app[/dim]                   Analyze a specific path
   [dim]/analyze . -o report.md[/dim]             Save report to file
-  [dim]/analyze . -o report.json -f json[/dim]   Export as JSON
-  [dim]/quick -i desc.txt -f sarif[/dim]         Quick model in SARIF format
+  [dim]/analyze . -o report.json -f json[/dim]   Export as JSON (pairs report.html)
+  [dim]/analyze . -o report.html -f html[/dim]   Export browser-viewable HTML
+  [dim]/quick -i desc.txt -f html -o r.html[/dim]  Quick model as HTML
   [dim]/reports[/dim]                            List recent reports
   [dim]/reports 1[/dim]                          View report #1
   [dim]/reports 1 -o r.md[/dim]                  Export report #1 to file
@@ -74,6 +75,7 @@ class OutputFormat(str, Enum):
     markdown = "markdown"
     json = "json"
     sarif = "sarif"
+    html = "html"
 
 
 class AppTypeOverride(str, Enum):
@@ -189,6 +191,7 @@ def _handle_config(config: dict) -> None:
 
 def _handle_analyze(config: dict, args_str: str) -> None:
     """Run agentic analysis from interactive session."""
+    from stride_gpt.agent.html_report import render_html
     from stride_gpt.agent.loop import create_analysis_plan, run_analysis
     from stride_gpt.agent.planner import format_plan_for_display
     from stride_gpt.agent.progress import RichProgress
@@ -267,26 +270,37 @@ def _handle_analyze(config: dict, args_str: str) -> None:
         rendered = render_markdown(report)
     elif output_format == OutputFormat.json:
         rendered = json.dumps(render_json(report), indent=2)
-    else:
+    elif output_format == OutputFormat.sarif:
         rendered = json.dumps(render_sarif(report), indent=2)
+    else:  # html
+        rendered = render_html(report)
 
     if output_path:
         output_path.write_text(rendered)
         console.print(f"\n[green]Report written to {output_path}[/green]")
+        # JSON output pairs an HTML companion next to it — JSON is the machine
+        # artifact, HTML is its human view.
+        if output_format == OutputFormat.json:
+            html_path = output_path.with_suffix(".html")
+            html_path.write_text(render_html(report))
+            console.print(f"[green]HTML view written to {html_path}[/green]")
     else:
         console.print()
         if output_format == OutputFormat.markdown:
             console.print(Markdown(rendered))
+        elif output_format == OutputFormat.html:
+            console.print("[dim]HTML reports must be written to a file with -o.[/dim]")
         else:
             console.print(rendered)
 
     if saved_path:
-        console.print(f"\n[dim]A copy of this report has been saved to {saved_path}[/dim]")
+        _print_saved_paths(saved_path)
         console.print("[dim]View previous reports with /reports[/dim]")
 
 
 def _handle_reports(args_str: str) -> None:
     """List or view previous analysis reports."""
+    from stride_gpt.agent.html_report import render_html_from_json
     from stride_gpt.agent.report import (
         list_reports,
         load_report,
@@ -385,22 +399,31 @@ def _handle_reports(args_str: str) -> None:
         rendered = render_markdown_from_json(data)
     elif output_format == OutputFormat.json:
         rendered = json.dumps(data, indent=2)
-    else:
+    elif output_format == OutputFormat.sarif:
         rendered = json.dumps(render_sarif_from_json(data), indent=2)
+    else:  # html
+        rendered = render_html_from_json(data)
 
     if output_path:
         output_path.write_text(rendered)
         console.print(f"[green]Report exported to {output_path}[/green]")
+        if output_format == OutputFormat.json:
+            html_path = output_path.with_suffix(".html")
+            html_path.write_text(render_html_from_json(data))
+            console.print(f"[green]HTML view written to {html_path}[/green]")
     else:
         console.print()
         if output_format == OutputFormat.markdown:
             console.print(Markdown(rendered))
+        elif output_format == OutputFormat.html:
+            console.print("[dim]HTML reports must be written to a file with -o.[/dim]")
         else:
             console.print(rendered)
 
 
 def _handle_quick(config: dict, args_str: str) -> None:
     """Run quick threat model from a description via the mini agent loop."""
+    from stride_gpt.agent.html_report import render_html_from_json
     from stride_gpt.agent.quick import run_quick_analysis
     from stride_gpt.agent.report import save_quick_report
     from stride_gpt.core.threat_model import json_to_markdown
@@ -410,6 +433,7 @@ def _handle_quick(config: dict, args_str: str) -> None:
     input_file: Path | None = None
     output_path: Path | None = None
     hint: str | None = None  # `-t/--type` is now an optional hint, not a switch
+    output_format = OutputFormat.markdown
 
     i = 0
     while i < len(parts):
@@ -421,6 +445,21 @@ def _handle_quick(config: dict, args_str: str) -> None:
             i += 2
         elif parts[i] in ("-t", "--type") and i + 1 < len(parts):
             hint = parts[i + 1]
+            i += 2
+        elif parts[i] in ("-f", "--format") and i + 1 < len(parts):
+            try:
+                output_format = OutputFormat(parts[i + 1])
+            except ValueError:
+                console.print(
+                    f"[red]Invalid format: {parts[i + 1]}. Use markdown or html.[/red]"
+                )
+                return
+            if output_format not in (OutputFormat.markdown, OutputFormat.html):
+                console.print(
+                    "[red]/quick only supports markdown and html output. "
+                    "For JSON or SARIF, see ~/.stride-gpt/reports/quick/.[/red]"
+                )
+                return
             i += 2
         else:
             i += 1
@@ -486,13 +525,20 @@ def _handle_quick(config: dict, args_str: str) -> None:
     markdown = json_to_markdown(result.threat_model, result.improvement_suggestions)
 
     if output_path:
-        output_path.write_text(markdown)
+        if output_format == OutputFormat.html:
+            # Re-render from the freshly saved JSON so /quick and /reports
+            # produce byte-identical HTML for the same analysis.
+            from stride_gpt.agent.report import load_report
+            html = render_html_from_json(load_report(saved_path))
+            output_path.write_text(html)
+        else:
+            output_path.write_text(markdown)
         console.print(f"[green]Report written to {output_path}[/green]")
     else:
         console.print()
         console.print(Markdown(markdown))
 
-    console.print(f"\n[dim]A copy of this report has been saved to {saved_path}[/dim]")
+    _print_saved_paths(saved_path)
     console.print("[dim]View previous quick reports with /reports --quick[/dim]")
 
 
@@ -536,6 +582,7 @@ def analyze(
     app_type: Annotated[AppTypeOverride, typer.Option("--app-type", help="Override the planner's app-type classification. 'auto' keeps the planner's choice.")] = AppTypeOverride.auto,
 ) -> None:
     """Deep agentic analysis of a codebase for STRIDE threats."""
+    from stride_gpt.agent.html_report import render_html
     from stride_gpt.agent.loop import create_analysis_plan, run_analysis
     from stride_gpt.agent.planner import format_plan_for_display
     from stride_gpt.agent.progress import RichProgress
@@ -615,19 +662,27 @@ def analyze(
         rendered = json.dumps(render_json(report), indent=2)
     elif output_format == OutputFormat.sarif:
         rendered = json.dumps(render_sarif(report), indent=2)
+    else:  # html
+        rendered = render_html(report)
 
     if output:
         output.write_text(rendered)
         console.print(f"\n[green]Report written to {output}[/green]")
+        if output_format == OutputFormat.json:
+            html_path = output.with_suffix(".html")
+            html_path.write_text(render_html(report))
+            console.print(f"[green]HTML view written to {html_path}[/green]")
     else:
         console.print()
         if output_format == OutputFormat.markdown:
             console.print(Markdown(rendered))
+        elif output_format == OutputFormat.html:
+            console.print("[dim]HTML reports must be written to a file with -o.[/dim]")
         else:
             console.print(rendered)
 
     if saved_path:
-        console.print(f"\n[dim]A copy of this report has been saved to {saved_path}[/dim]")
+        _print_saved_paths(saved_path)
         console.print("[dim]View previous reports with: stride-gpt reports[/dim]")
 
 
@@ -645,11 +700,20 @@ def quick(
     input_file: Annotated[Optional[Path], typer.Option("-i", "--input", help="App description file.")] = None,
     app_type: Annotated[Optional[str], typer.Option(help="Optional hint about the application type (Web / Generative AI / Agentic AI application). Leave unset to let the agent decide which reference cards to load.")] = None,
     output: Annotated[Optional[Path], typer.Option("-o", "--output", help="Output file path.")] = None,
+    output_format: Annotated[OutputFormat, typer.Option("-f", "--format", help="Output format: markdown (default) or html.")] = OutputFormat.markdown,
 ) -> None:
     """Quick threat model from a text description, via the mini agent loop."""
+    from stride_gpt.agent.html_report import render_html_from_json
     from stride_gpt.agent.quick import run_quick_analysis
-    from stride_gpt.agent.report import save_quick_report
+    from stride_gpt.agent.report import load_report, save_quick_report
     from stride_gpt.core.threat_model import json_to_markdown
+
+    if output_format not in (OutputFormat.markdown, OutputFormat.html):
+        console.print(
+            "[red]/quick only supports markdown and html output. "
+            "For JSON or SARIF, see ~/.stride-gpt/reports/quick/.[/red]"
+        )
+        raise typer.Exit(2)
 
     models = _build_model_pair(
         worker_model=worker_model,
@@ -702,13 +766,17 @@ def quick(
     markdown = json_to_markdown(result.threat_model, result.improvement_suggestions)
 
     if output:
-        output.write_text(markdown)
+        if output_format == OutputFormat.html:
+            html = render_html_from_json(load_report(saved_path))
+            output.write_text(html)
+        else:
+            output.write_text(markdown)
         console.print(f"[green]Report written to {output}[/green]")
     else:
         console.print()
         console.print(Markdown(markdown))
 
-    console.print(f"\n[dim]A copy of this report has been saved to {saved_path}[/dim]")
+    _print_saved_paths(saved_path)
     console.print("[dim]View previous quick reports with: stride-gpt reports --quick[/dim]")
 
 
@@ -722,6 +790,7 @@ def reports(
     all_kinds: Annotated[bool, typer.Option("--all", help="List both /analyze and /quick reports.")] = False,
 ) -> None:
     """List or view previous analysis reports."""
+    from stride_gpt.agent.html_report import render_html_from_json
     from stride_gpt.agent.report import (
         list_reports,
         load_report,
@@ -778,16 +847,24 @@ def reports(
         rendered = render_markdown_from_json(data)
     elif output_format == OutputFormat.json:
         rendered = json.dumps(data, indent=2)
-    else:
+    elif output_format == OutputFormat.sarif:
         rendered = json.dumps(render_sarif_from_json(data), indent=2)
+    else:  # html
+        rendered = render_html_from_json(data)
 
     if output:
         output.write_text(rendered)
         console.print(f"[green]Report exported to {output}[/green]")
+        if output_format == OutputFormat.json:
+            html_path = output.with_suffix(".html")
+            html_path.write_text(render_html_from_json(data))
+            console.print(f"[green]HTML view written to {html_path}[/green]")
     else:
         console.print()
         if output_format == OutputFormat.markdown:
             console.print(Markdown(rendered))
+        elif output_format == OutputFormat.html:
+            console.print("[dim]HTML reports must be written to a file with -o.[/dim]")
         else:
             console.print(rendered)
 
@@ -795,6 +872,18 @@ def reports(
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _print_saved_paths(saved_path: Path) -> None:
+    """Tell the user where the auto-saved JSON went, plus the HTML companion.
+
+    The HTML companion is best-effort (see _write_html_companion); we mention
+    it only when the sibling actually exists.
+    """
+    console.print(f"\n[dim]A copy of this report has been saved to {saved_path}[/dim]")
+    html_sibling = saved_path.with_suffix(".html")
+    if html_sibling.exists():
+        console.print(f"[dim]HTML view: {html_sibling}[/dim]")
 
 
 def _build_model_pair(

--- a/stride_gpt/cli.py
+++ b/stride_gpt/cli.py
@@ -59,15 +59,15 @@ HELP_TEXT = """
   [cyan]-y, --yes[/cyan]              Auto-approve the analysis plan
 
 [bold]Examples:[/bold]
-  [dim]/analyze .[/dim]                          Analyze current directory
-  [dim]/analyze ./my-app[/dim]                   Analyze a specific path
-  [dim]/analyze . -o report.md[/dim]             Save report to file
-  [dim]/analyze . -o report.json -f json[/dim]   Export as JSON (pairs report.html)
-  [dim]/analyze . -o report.html -f html[/dim]   Export browser-viewable HTML
-  [dim]/quick -i desc.txt -f html -o r.html[/dim]  Quick model as HTML
-  [dim]/reports[/dim]                            List recent reports
-  [dim]/reports 1[/dim]                          View report #1
-  [dim]/reports 1 -o r.md[/dim]                  Export report #1 to file
+  [cyan]/analyze .[/cyan]                          Analyze current directory
+  [cyan]/analyze ./my-app[/cyan]                   Analyze a specific path
+  [cyan]/analyze . -o report.md[/cyan]             Save report to file
+  [cyan]/analyze . -o report.json -f json[/cyan]   Export as JSON (pairs report.html)
+  [cyan]/analyze . -o report.html -f html[/cyan]   Export browser-viewable HTML
+  [cyan]/quick -i desc.txt -f html -o r.html[/cyan]  Quick model as HTML
+  [cyan]/reports[/cyan]                            List recent reports
+  [cyan]/reports 1[/cyan]                          View report #1
+  [cyan]/reports 1 -o r.md[/cyan]                  Export report #1 to file
 """
 
 
@@ -168,14 +168,14 @@ def interactive(ctx: typer.Context) -> None:
 
         elif user_input.startswith("/"):
             console.print(f"[red]Unknown command: {user_input.split()[0]}[/red]")
-            console.print("[dim]Type /help for available commands.[/dim]")
+            console.print("[dim]Type[/dim] [cyan]/help[/cyan] [dim]for available commands.[/dim]")
 
         else:
             # Bare path — treat as /analyze
             if Path(user_input).is_dir():
                 _handle_analyze(config, user_input)
             else:
-                console.print("[dim]Type /help for available commands, or enter a directory path to analyze.[/dim]")
+                console.print("[dim]Type[/dim] [cyan]/help[/cyan] [dim]for available commands, or enter a directory path to analyze.[/dim]")
 
 
 def _handle_config(config: dict) -> None:
@@ -217,7 +217,7 @@ def _handle_analyze(config: dict, args_str: str) -> None:
             try:
                 output_format = OutputFormat(parts[i + 1])
             except ValueError:
-                console.print(f"[red]Invalid format: {parts[i + 1]}. Use markdown, json, or sarif.[/red]")
+                console.print(f"[red]Invalid format: {parts[i + 1]}. Use markdown, json, sarif, or html.[/red]")
                 return
             i += 2
         elif parts[i] in ("-y", "--yes"):
@@ -295,7 +295,7 @@ def _handle_analyze(config: dict, args_str: str) -> None:
 
     if saved_path:
         _print_saved_paths(saved_path)
-        console.print("[dim]View previous reports with /reports[/dim]")
+        console.print("[dim]View previous reports with[/dim] [cyan]/reports[/cyan]")
 
 
 def _handle_reports(args_str: str) -> None:
@@ -355,10 +355,13 @@ def _handle_reports(args_str: str) -> None:
         console.print()
         console.print(table)
         console.print()
-        view_hint = "/reports <number>"
         if kind == "analyze":
-            view_hint += "   |   /reports --quick   to list quick reports"
-        console.print(f"[dim]View a report: {view_hint}[/dim]")
+            console.print(
+                "[dim]View a report:[/dim] [cyan]/reports <number>[/cyan]   "
+                "[dim]|[/dim]   [cyan]/reports --quick[/cyan] [dim]to list quick reports[/dim]"
+            )
+        else:
+            console.print("[dim]View a report:[/dim] [cyan]/reports <number>[/cyan]")
         return
 
     # View/export mode — first arg is the report number
@@ -389,7 +392,7 @@ def _handle_reports(args_str: str) -> None:
             try:
                 output_format = OutputFormat(parts[i + 1])
             except ValueError:
-                console.print(f"[red]Invalid format: {parts[i + 1]}. Use markdown, json, or sarif.[/red]")
+                console.print(f"[red]Invalid format: {parts[i + 1]}. Use markdown, json, sarif, or html.[/red]")
                 return
             i += 2
         else:
@@ -539,7 +542,7 @@ def _handle_quick(config: dict, args_str: str) -> None:
         console.print(Markdown(markdown))
 
     _print_saved_paths(saved_path)
-    console.print("[dim]View previous quick reports with /reports --quick[/dim]")
+    console.print("[dim]View previous quick reports with[/dim] [cyan]/reports --quick[/cyan]")
 
 
 # ---------------------------------------------------------------------------
@@ -683,7 +686,7 @@ def analyze(
 
     if saved_path:
         _print_saved_paths(saved_path)
-        console.print("[dim]View previous reports with: stride-gpt reports[/dim]")
+        console.print("[dim]View previous reports with:[/dim] [cyan]stride-gpt reports[/cyan]")
 
 
 @app.command()
@@ -777,7 +780,7 @@ def quick(
         console.print(Markdown(markdown))
 
     _print_saved_paths(saved_path)
-    console.print("[dim]View previous quick reports with: stride-gpt reports --quick[/dim]")
+    console.print("[dim]View previous quick reports with:[/dim] [cyan]stride-gpt reports --quick[/cyan]")
 
 
 @app.command()
@@ -878,12 +881,14 @@ def _print_saved_paths(saved_path: Path) -> None:
     """Tell the user where the auto-saved JSON went, plus the HTML companion.
 
     The HTML companion is best-effort (see _write_html_companion); we mention
-    it only when the sibling actually exists.
+    it only when the sibling actually exists. Paths are coloured rather than
+    dimmed — Rich's auto-link styling on dim text becomes near-illegible on
+    dark terminal backgrounds.
     """
-    console.print(f"\n[dim]A copy of this report has been saved to {saved_path}[/dim]")
+    console.print(f"\n[dim]A copy of this report has been saved to[/dim] [cyan]{saved_path}[/cyan]")
     html_sibling = saved_path.with_suffix(".html")
     if html_sibling.exists():
-        console.print(f"[dim]HTML view: {html_sibling}[/dim]")
+        console.print(f"[dim]HTML view:[/dim] [cyan]{html_sibling}[/cyan]")
 
 
 def _build_model_pair(

--- a/stride_gpt/config.py
+++ b/stride_gpt/config.py
@@ -515,7 +515,7 @@ def show_config(console: Console, config: dict[str, Any]) -> None:
     else:
         console.print("[dim]No architect tier configured — worker handles every call.[/dim]")
     console.print()
-    console.print(f"[dim]Config file: {CONFIG_FILE}[/dim]")
+    console.print(f"[dim]Config file:[/dim] [cyan]{CONFIG_FILE}[/cyan]")
 
 
 def get_api_key(config: dict[str, Any], *, tier: str = "worker") -> str:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from stride_gpt.agent.html_report import render_html, render_html_from_json
 from stride_gpt.agent.report import (
     render_json,
     render_markdown,
@@ -384,6 +385,200 @@ class TestInsiderCategoryColumn:
 # ---------------------------------------------------------------------------
 # Report persistence — separate folders for /analyze and /quick
 # ---------------------------------------------------------------------------
+
+
+class TestRenderHtml:
+    """The HTML renderer is the human-facing companion to the JSON report.
+    Tests assert on shape and key fragments, not whole-document bytes — the
+    Tailwind class soup will churn often, but the structural anchors won't."""
+
+    def test_doctype_and_scaffold(self, sample_report: AnalysisReport):
+        html = render_html(sample_report)
+        assert html.startswith("<!doctype html>")
+        assert "tailwindcss.com" in html  # Tailwind CDN present
+        assert "<title>STRIDE Threat Model" in html
+
+    def test_target_name_in_header(self, sample_report: AnalysisReport):
+        html = render_html(sample_report)
+        # plan.target_path = "/tmp/test-app" → name "test-app"
+        assert "test-app" in html
+
+    def test_renders_stride_badges_for_threats(self, sample_report: AnalysisReport):
+        html = render_html(sample_report)
+        # Each threat should appear in a card; the Spoofing badge class is the
+        # canonical "category coding works" smoke check.
+        assert "Spoofing" in html
+        assert "bg-indigo-100" in html
+        assert "brute-force" in html
+
+    def test_renders_cross_cutting_section(self, sample_report: AnalysisReport):
+        html = render_html(sample_report)
+        assert "Cross-cutting threats" in html
+        assert "CSRF" in html
+        # Affected subsystems should appear as pills, not a comma-joined string
+        assert ">Auth<" in html
+        assert ">API<" in html
+
+    def test_renders_recommendations(self, sample_report: AnalysisReport):
+        html = render_html(sample_report)
+        assert "Recommendations" in html
+        assert "rate limiting" in html
+
+    def test_renders_files_analyzed(self, sample_report: AnalysisReport):
+        html = render_html(sample_report)
+        assert "Files analyzed" in html
+        assert "auth.py" in html
+        assert "font-mono" in html
+
+    def test_summary_chips_present(self, sample_report: AnalysisReport):
+        html = render_html(sample_report)
+        # 2 subsystem threats + 1 cross-cutting = 3
+        assert "3 threats" in html
+        assert "1 cross-cutting" in html
+
+    def test_escapes_hostile_threat_text(self, sample_plan):
+        """A threat carrying <script> must not render as a live tag.
+        The renderer is for human review of analysis output, but treat any
+        LLM-produced text as untrusted on the way to a browser."""
+        from stride_gpt.core.schemas import SubsystemFinding
+
+        report = AnalysisReport(
+            plan=sample_plan,
+            findings=[SubsystemFinding(
+                subsystem="Auth",
+                threats=[{
+                    "Threat Type": "Tampering",
+                    "Scenario": "<script>alert('xss')</script>",
+                    "Potential Impact": "User session hijack via </body><script>x</script>",
+                }],
+            )],
+            metadata={},
+        )
+        html = render_html(report)
+        assert "<script>alert" not in html
+        assert "&lt;script&gt;alert" in html
+
+    def test_owasp_pills_appear_when_codes_present(self, sample_plan):
+        report = _report_with_owasp(sample_plan, owasp_llm="LLM01", owasp_asi="ASI06")
+        html = render_html(report)
+        assert "OWASP LLM01" in html
+        assert "ASI ASI06" in html
+
+    def test_owasp_pills_absent_when_codes_missing(self, sample_report: AnalysisReport):
+        """A standard web app has no OWASP_LLM/ASI; pills must not appear at all
+        (not even as empty containers)."""
+        html = render_html(sample_report)
+        assert "OWASP " not in html
+        assert "ASI " not in html
+
+    def test_insider_category_pill(self, sample_plan):
+        from stride_gpt.core.schemas import SubsystemFinding
+
+        report = AnalysisReport(
+            plan=sample_plan,
+            findings=[SubsystemFinding(
+                subsystem="Agent",
+                threats=[{
+                    "Threat Type": "Information Disclosure",
+                    "Scenario": "Agent harvests env vars",
+                    "Potential Impact": "Lateral movement",
+                    "INSIDER_CATEGORY": "Data Exfiltration",
+                }],
+            )],
+            metadata={},
+        )
+        html = render_html(report)
+        assert "Insider: Data Exfiltration" in html
+
+    def test_quick_report_renders_with_single_subsystem(self, sample_plan):
+        """The /quick path saves a synthetic 'Application' subsystem with no
+        files_analyzed and an empty overview — the renderer must handle that
+        gracefully (no orphan headers, no empty Files-analyzed block)."""
+        quick_data = {
+            "version": "1.0",
+            "kind": "quick",
+            "generated_at": "2026-01-15T12:00:00+00:00",
+            "target": "my-saas-app",
+            "overview": "",
+            "subsystems": [{
+                "name": "Application",
+                "threats": [{
+                    "Threat Type": "Spoofing",
+                    "Scenario": "Weak password policy",
+                    "Potential Impact": "Account takeover",
+                }],
+                "improvement_suggestions": ["Require MFA"],
+                "files_analyzed": [],
+            }],
+            "cross_cutting_threats": [],
+            "metadata": {"kind": "quick"},
+        }
+        html = render_html_from_json(quick_data)
+        assert "my-saas-app" in html
+        assert "Application" in html
+        assert "Files analyzed" not in html
+        assert "Cross-cutting" not in html
+        # Subsystem count chip suppressed for /quick (only one subsystem)
+        assert "1 subsystems" not in html
+
+    def test_round_trip_via_saved_json(self, sample_report: AnalysisReport, tmp_path):
+        """The disk-replay path must produce byte-identical HTML to a live
+        render — /analyze and /reports share rendering."""
+        live = render_html(sample_report)
+        replay = render_html_from_json(render_json(sample_report))
+        # generated_at is computed at render time from data["generated_at"]
+        # which is set by render_json, so the two should match.
+        assert live == replay
+
+    def test_unknown_stride_category_falls_back(self, sample_plan):
+        """An unrecognised Threat Type must still render — fall back to the
+        neutral badge rather than KeyError."""
+        from stride_gpt.core.schemas import SubsystemFinding
+
+        report = AnalysisReport(
+            plan=sample_plan,
+            findings=[SubsystemFinding(
+                subsystem="X",
+                threats=[{
+                    "Threat Type": "Some Future Category",
+                    "Scenario": "s",
+                    "Potential Impact": "i",
+                }],
+            )],
+            metadata={},
+        )
+        html = render_html(report)
+        assert "Some Future Category" in html
+
+    def test_auto_save_writes_html_companion(
+        self, sample_report: AnalysisReport, tmp_path
+    ):
+        """save_report() must write a .html sibling alongside the .json so
+        users get a browser-viewable report for free."""
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("stride_gpt.config.REPORTS_DIR", tmp_path)
+            json_path = save_report(sample_report)
+            html_path = json_path.with_suffix(".html")
+            assert html_path.exists()
+            content = html_path.read_text()
+            assert content.startswith("<!doctype html>")
+            assert "Spoofing" in content
+
+    def test_quick_auto_save_writes_html_companion(self, tmp_path, model_pair):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("stride_gpt.config.REPORTS_DIR", tmp_path)
+            output = ThreatModelOutput(
+                threat_model=[{
+                    "Threat Type": "Spoofing",
+                    "Scenario": "x",
+                    "Potential Impact": "y",
+                }],
+                improvement_suggestions=["test"],
+            )
+            json_path = save_quick_report(output, "atlas", models=model_pair)
+            html_path = json_path.with_suffix(".html")
+            assert html_path.exists()
+            assert "atlas" in html_path.read_text()
 
 
 class TestSplitReportFolders:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -408,7 +408,7 @@ class TestRenderHtml:
         # Each threat should appear in a card; the Spoofing badge class is the
         # canonical "category coding works" smoke check.
         assert "Spoofing" in html
-        assert "bg-indigo-100" in html
+        assert "bg-indigo-50" in html
         assert "brute-force" in html
 
     def test_renders_cross_cutting_section(self, sample_report: AnalysisReport):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -395,7 +395,9 @@ class TestRenderHtml:
     def test_doctype_and_scaffold(self, sample_report: AnalysisReport):
         html = render_html(sample_report)
         assert html.startswith("<!doctype html>")
-        assert "tailwindcss.com" in html  # Tailwind CDN present
+        # Pin the exact CDN script tag rather than the bare hostname — CodeQL
+        # otherwise mistakes the substring check for URL allowlist sanitization.
+        assert '<script src="https://cdn.tailwindcss.com">' in html
         assert "<title>STRIDE Threat Model" in html
 
     def test_target_name_in_header(self, sample_report: AnalysisReport):


### PR DESCRIPTION
## Summary

- New `stride_gpt/agent/html_report.py` renders a self-contained, Tailwind-styled HTML view of any STRIDE report. STRIDE category drives toned-down badges with matching rings; OWASP_LLM, OWASP_ASI, and INSIDER_CATEGORY surface as outline pills when present.
- Every auto-saved JSON in `~/.stride-gpt/reports/` now gets a `.html` sibling for free. Best-effort: a render bug never costs the user their analysis.
- `-f html` exposed on `/analyze`, `/quick`, and `/reports`. `-f json -o foo.json` additionally pairs `foo.html` so the human view ships next to the machine artifact.

Style cribbed from Matt Pocock's [improve-codebase-architecture](https://github.com/mattpocock/skills/blob/main/skills/engineering/improve-codebase-architecture/HTML-REPORT.md) and adapted for threat modeling — `› stride-gpt threat-model` brand mark, slate palette, mono captions, sans type hierarchy.

### Scope creep (small)

While reviewing the rendered output we also tightened the CLI text contrast — paths and slash-commands inside `[dim]` blocks were being auto-styled by Rich into near-illegible dark purple on dark terminals. Pulled them out into `[cyan]` to match the convention used elsewhere (`_panel_target_body`). Touches `/help`, banner examples, `/config` display line, post-run "saved to" lines, and the "View previous reports with `/reports`" hints. Also updated the stale `Invalid format: Use markdown, json, or sarif` error to include `html`.

## Test plan

- [ ] `python3 -m pytest tests/test_report.py` — 54 pass, including 16 new `TestRenderHtml` cases (badges, XSS escaping, OWASP/Insider pill presence, `/quick` single-subsystem case, round-trip equivalence, auto-save companion)
- [ ] `stride-gpt analyze ./some-repo -y -f html -o /tmp/r.html && open /tmp/r.html` renders the expected visual
- [ ] `stride-gpt quick -i desc.txt -f html -o /tmp/q.html && open /tmp/q.html` renders cleanly for the synthetic "Application" subsystem
- [ ] `stride-gpt analyze . -y -f json -o /tmp/r.json` produces both `/tmp/r.json` and `/tmp/r.html`
- [ ] `stride-gpt reports 1 -f html -o /tmp/x.html` re-renders a saved report
- [ ] Run-end summary line shows the HTML companion path in cyan, legible on a dark terminal
- [ ] `/help`, `/config`, and the "View previous reports" hint show slash-commands in cyan, not dim-purple
- [ ] `stride-gpt analyze . -f bogus` now suggests `markdown, json, sarif, or html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
