### PR TITLE
chore: Remove five tests that exercise dependencies, not stride-gpt

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -72,13 +72,6 @@ class TestResolveLimit:
 
 class TestCountTokens:
     @patch("stride_gpt.agent.context.litellm")
-    def test_uses_litellm_counter(self, mock_litellm, ctx):
-        mock_litellm.token_counter.return_value = 42
-        msgs = [{"role": "user", "content": "hello"}]
-        assert ctx.count_tokens(msgs) == 42
-        mock_litellm.token_counter.assert_called_once()
-
-    @patch("stride_gpt.agent.context.litellm")
     def test_fallback_on_error(self, mock_litellm, ctx):
         mock_litellm.token_counter.side_effect = Exception("boom")
         msgs = [{"role": "user", "content": "a" * 400}]

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -3,13 +3,8 @@
 from __future__ import annotations
 
 import queue
-from unittest.mock import MagicMock
 
-from stride_gpt.agent.progress import (
-    ProgressCallback,
-    QueueProgress,
-    RichProgress,
-)
+from stride_gpt.agent.progress import QueueProgress
 
 
 class TestQueueProgress:
@@ -85,27 +80,3 @@ class TestQueueProgress:
         assert q.qsize() == 7
 
 
-class TestRichProgress:
-    def test_phase_start_calls_console(self):
-        console = MagicMock()
-        p = RichProgress(console)
-        p.phase_start("Phase 1", "Planning")
-        console.print.assert_called_once()
-
-    def test_subsystem_done_calls_console(self):
-        console = MagicMock()
-        p = RichProgress(console)
-        p.subsystem_done("Auth", 5)
-        console.print.assert_called_once()
-
-
-class TestProtocol:
-    def test_queue_progress_satisfies_protocol(self):
-        q: queue.Queue = queue.Queue()
-        p = QueueProgress(q)
-        assert isinstance(p, ProgressCallback)
-
-    def test_rich_progress_satisfies_protocol(self):
-        console = MagicMock()
-        p = RichProgress(console)
-        assert isinstance(p, ProgressCallback)


### PR DESCRIPTION
## Summary

Test-quality audit identified five tests whose assertions belong to a third-party library rather than our own logic. Removing them tightens the signal:fail ratio of the suite without losing real coverage.

| Removed | Why |
|---|---|
| `test_progress.py::TestRichProgress::test_phase_start_calls_console` | `RichProgress.phase_start` is `self.console.print(...)` — asserting print was called proves nothing. |
| `test_progress.py::TestRichProgress::test_subsystem_done_calls_console` | Same as above. |
| `test_progress.py::TestProtocol::test_queue_progress_satisfies_protocol` | Asserts `isinstance(QueueProgress, ProgressCallback)` — tests Python's typing machinery, not us. |
| `test_progress.py::TestProtocol::test_rich_progress_satisfies_protocol` | Same as above. |
| `test_context.py::TestCountTokens::test_uses_litellm_counter` | Mocks `litellm.token_counter` to return 42, asserts 42 comes back. Tests the mock. Sibling `test_fallback_on_error` stays — that one exercises our real fallback path. |

Tightening pass kept:

- `test_llm_kwargs.py` — initially flagged but actually a regression suite for our provider-specific kwarg logic (Gemini rejecting Anthropic's `thinking` kwarg, etc.). Real bugs are pinned here.
- `TestResolveLimit`, `TestNeedsCompression` — initially flagged but exercise our model-registry fallback and threshold-decision logic.
- `TestOwaspColumns` (12 tests) — initially flagged as redundant but each variant covers a distinct branch of the conditional-column rendering.

## Test plan

- [x] `python3 -m pytest` — 240 pass (was 245)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)