### PR TITLE
chore: Refresh python:3.12-slim base to clear 8 CVE alerts

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Build Docker image
-        run: docker build -t stride-gpt:${{ github.sha }} .
+        run: docker build -f Dockerfile.ui -t stride-gpt:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,7 +1,7 @@
 # Streamlit web UI image for STRIDE-GPT.
 # The CLI is published to PyPI (`pip install stride-gpt`); no separate CLI image.
 
-FROM python:3.12-slim@sha256:d86b4c74b936c438cd4cc3a9f7256b9a7c27ad68c7caf8c205e18d9845af0164
+FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
 
 ENV PYTHONUNBUFFERED=1
 ENV PIP_ROOT_USER_ACTION=ignore


### PR DESCRIPTION
## Summary
- Bumps the pinned `python:3.12-slim` digest in `Dockerfile.ui` to the current image. The fresh base ships Debian Trixie with patched `openssl 3.5.6-1~deb13u1` and `libcap2 1:2.75-10+deb13u1+b1`.
- Fixes the `docker-security` workflow's build step, which still ran `docker build .` even though the Dockerfile was renamed to `Dockerfile.ui` in da5785d. The job has been silently broken since that commit.

## CVEs cleared
This refresh closes 24 of the 27 open Trivy alerts on master:

| CVE | Severity | Package(s) |
|---|---|---|
| CVE-2026-31789 | **Critical** | openssl, libssl3t64, openssl-provider-legacy |
| CVE-2026-28387/8/9/90 | High | openssl, libssl3t64, openssl-provider-legacy |
| CVE-2025-69421 | High | openssl, libssl3t64, openssl-provider-legacy |
| CVE-2025-15467 | High | openssl, libssl3t64, openssl-provider-legacy |
| CVE-2026-4878 | High | libcap2 |

Remaining CVEs (CVE-2025-69720 in ncurses, CVE-2026-8376 in perl-base) have no fix in Debian Trixie yet — nothing actionable until upstream patches land.

## Test plan
- [x] `docker build -f Dockerfile.ui -t stride-gpt:cve-refresh-test .` succeeds locally
- [x] Local Trivy scan of the rebuilt image shows 0 critical/high in openssl, libssl3t64, openssl-provider-legacy, libcap2 (down from 8 CVEs across 24 alert instances)
- [ ] `docker-security` workflow on this PR completes and SARIF upload reflects the reduced alert set

🤖 Generated with [Claude Code](https://claude.com/claude-code)