### PR TITLE
Clear CodeQL note alerts: unused imports, bare except, dead code

### DIFF
--- a/apps/web/attack_tree.py
+++ b/apps/web/attack_tree.py
@@ -1,4 +1,3 @@
-import json
 import re
 
 import streamlit as st

--- a/apps/web/main.py
+++ b/apps/web/main.py
@@ -11,7 +11,6 @@ if str(_REPO_ROOT) not in sys.path:
 
 import base64
 import html
-import json
 import os
 import re
 from collections import defaultdict
@@ -22,7 +21,7 @@ import streamlit as st
 import streamlit.components.v1 as components
 import tiktoken
 from dotenv import load_dotenv
-from github import Github
+from github import Github, GithubException
 from openai import OpenAI
 
 from attack_tree import (
@@ -412,18 +411,14 @@ def analyze_github_repo(repo_url):
         readme_file = repo.get_contents("README.md", ref=default_branch)
         readme_content = base64.b64decode(readme_file.content).decode()
         readme_tokens = estimate_tokens(readme_content, token_estimation_model)
-    except:
+    except GithubException:
         try:
             # Try lowercase readme.md as fallback
             readme_file = repo.get_contents("readme.md", ref=default_branch)
             readme_content = base64.b64decode(readme_file.content).decode()
             readme_tokens = estimate_tokens(readme_content, token_estimation_model)
-        except:
+        except GithubException:
             st.warning("No README.md found in the repository.")
-
-    # Calculate how many tokens we can use for code analysis
-    # Reserve at least 30% of the token limit for code analysis
-    max(int(analysis_token_limit * 0.3), analysis_token_limit - readme_tokens)
 
     # If README is too large, truncate it
     if readme_tokens > analysis_token_limit * 0.7:

--- a/apps/web/utils.py
+++ b/apps/web/utils.py
@@ -3,3 +3,11 @@
 from stride_gpt.core.attack_tree import clean_mermaid_syntax, extract_mermaid_code
 from stride_gpt.core.llm import extract_deepseek_reasoning, process_groq_response
 from stride_gpt.core.prompts import create_reasoning_system_prompt
+
+__all__ = [
+    "clean_mermaid_syntax",
+    "extract_mermaid_code",
+    "extract_deepseek_reasoning",
+    "process_groq_response",
+    "create_reasoning_system_prompt",
+]

--- a/stride_gpt/agent/report.py
+++ b/stride_gpt/agent/report.py
@@ -13,7 +13,7 @@ from stride_gpt.core.report_utils import (
     threat_table_header,
     threat_table_row,
 )
-from stride_gpt.core.schemas import AnalysisReport, ModelPair, SubsystemFinding, ThreatModelOutput
+from stride_gpt.core.schemas import AnalysisReport, ModelPair, ThreatModelOutput
 
 
 def render_markdown(report: AnalysisReport) -> str:

--- a/stride_gpt/cli.py
+++ b/stride_gpt/cli.py
@@ -18,14 +18,13 @@ import typer
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
-from rich.prompt import Confirm, Prompt
+from rich.prompt import Confirm
 from rich.table import Table
 
 from stride_gpt.config import (
     config_to_model_pair,
     load_config,
     run_setup,
-    save_config,
     show_config,
 )
 

--- a/stride_gpt/prompt.py
+++ b/stride_gpt/prompt.py
@@ -85,7 +85,6 @@ class StrideCompleter(Completer):
         if cmd in PATH_COMMANDS and not last_token.startswith("-"):
             # Look back: is this still the first positional arg?
             tokens_before = parts[1:-1] if last_token else parts[1:]
-            non_flag_args = [t for t in tokens_before if not t.startswith("-")]
             # Skip flag values
             skip_next = False
             count = 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from stride_gpt.core.schemas import (
     AnalysisPlan,
     AnalysisReport,
     LLMConfig,
-    LLMResponse,
     ModelPair,
     SubsystemFinding,
     Subsystem,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -13,10 +13,8 @@ from stride_gpt.agent.loop import (
     _strip_tool_artifacts,
     _summarize_for_analysis,
     _synthesize,
-    create_analysis_plan,
     run_analysis,
 )
-from stride_gpt.agent.progress import RichProgress
 from stride_gpt.core.schemas import (
     AnalysisPlan,
     LLMResponse,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -9,7 +9,6 @@ import pytest
 
 from stride_gpt.agent.tools import (
     AGENT_TOOLS,
-    MAX_FILE_SIZE,
     execute_tool,
     grep_content,
     list_directory,


### PR DESCRIPTION
## Summary
- **apps/web/main.py:** replace two bare \`except:\` blocks in the README loader with \`except GithubException:\` (clears \`py/catch-base-exception\`).
- **apps/web/main.py:** drop a stray \`max(...)\` whose result was thrown away. The comment claimed it "reserves 30% for code analysis", but the would-be result was never assigned and \`analysis_token_limit\` is still passed through unmodified at line 500 — so this is dead code from a never-completed feature, not a missing-assignment bug. Removing it preserves current behavior.
- **apps/web/utils.py:** add \`__all__\` so the deliberate back-compat re-exports stop firing \`py/unused-import\` on every scan.
- Drop genuinely-unused imports across \`apps/web/{main,attack_tree}.py\`, \`stride_gpt/{cli,agent/report}.py\`, and five test files.
- Drop one unused local in \`stride_gpt/prompt.py\`.

## What's intentionally NOT changed
The remaining CodeQL note alerts (17 of them) are idiomatic Python/Streamlit patterns CodeQL mis-flags: \`...\` in \`typing.Protocol\` method bodies, function-local imports to break circular deps, Streamlit \`selected_model\` redefined across if/else branches, and widgets like \`mermaid_live_button\` called for their side effect. Left in place rather than dismissed one-by-one — they'd just re-appear on the next scan.

## Test plan
- [x] \`pytest -q\`: 240 passed
- [x] \`python -c "import ast"\` smoke check on the edited files (no syntax regressions in Streamlit code that pytest doesn't cover)
- [x] \`import apps.web.utils\` resolves the \`__all__\` list correctly
- [ ] CodeQL re-runs on merge to master and the addressed alerts close

🤖 Generated with [Claude Code](https://claude.com/claude-code)