### PR TITLE
Drop unused mistralai dependency

### DIFF
--- a/apps/web/requirements.txt
+++ b/apps/web/requirements.txt
@@ -9,7 +9,6 @@ httpx>=0.27
 python-dotenv>=1.0
 openai
 anthropic
-mistralai>=1.0.0
 groq
 pyGithub
 tiktoken


### PR DESCRIPTION
## Summary
Remove \`mistralai>=1.0.0\` from \`apps/web/requirements.txt\` — it is never imported.

## Why
Mistral is a first-class provider in STRIDE-GPT, but the actual API calls go through **LiteLLM**, not the mistralai SDK directly. \`stride_gpt/models.py:95\` registers Mistral with \`litellm_prefix="mistral/"\`, and a grep across \`apps/\` and \`stride_gpt/\` for \`from mistralai\` / \`import mistralai\` returns zero matches. The SDK has been dead weight in the venv for a while — leftover from the pre-LiteLLM era.

Removing it:
- shrinks the install footprint
- eliminates the supply-chain surface for an unused dep
- stops Dependabot from continually opening bumps for it (this PR also supersedes #109)

## Test plan
- [x] \`pytest -q\`: 240 passed
- [x] Confirmed Mistral routing path through \`stride_gpt/core/llm.py:130\` (\`config.provider == "Mistral API"\`) goes via LiteLLM and does not touch the mistralai module
- [ ] Streamlit Community Cloud rebuilds cleanly on merge

## Follow-up
Closes #109 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)