### PR TITLE
feat: persist structured intermediates alongside exported reports (#122)

### DIFF
--- a/stride_gpt/agent/loop.py
+++ b/stride_gpt/agent/loop.py
@@ -96,6 +96,10 @@ def run_analysis(
     ctx = ContextManager(config=models.worker)
     llm_calls = 0
     tool_calls = 0
+    # Names the agent loads via the ``load_reference`` tool. Surfaced on
+    # ``report.metadata["references_loaded"]`` so the run manifest can record
+    # which cards actually shaped the output.
+    loaded_refs: set[str] = set()
 
     # --- Phase 1: Planning ---
     if plan is None:
@@ -114,13 +118,15 @@ def run_analysis(
                 response = console.input("[bold yellow]Approve this plan? (y/n/q): [/bold yellow]")
                 if response.lower() not in ("y", "yes"):
                     progress.complete("Analysis cancelled.")
+                    cancel_meta = _build_metadata(
+                        models, plan, llm_calls=llm_calls, tool_calls=tool_calls,
+                        subsystems_analyzed=0, status="cancelled",
+                    )
+                    cancel_meta["references_loaded"] = sorted(loaded_refs)
                     return AnalysisReport(
                         plan=plan,
                         findings=[],
-                        metadata=_build_metadata(
-                            models, plan, llm_calls=llm_calls, tool_calls=tool_calls,
-                            subsystems_analyzed=0, status="cancelled",
-                        ),
+                        metadata=cancel_meta,
                     )
             # If no console and not auto_approve, proceed anyway
             # (caller should use the split API for interactive approval)
@@ -169,6 +175,7 @@ def run_analysis(
                 max_tool_calls=remaining_tool,
                 progress=progress,
                 call_counts=sub_counts,
+                loaded_refs=loaded_refs,
             )
             llm_calls += sub_counts["llm"]
             tool_calls += sub_counts["tool"]
@@ -215,15 +222,18 @@ def run_analysis(
         except Exception:
             data_flow_diagram = None
 
+    metadata = _build_metadata(
+        models, plan, llm_calls=llm_calls, tool_calls=tool_calls,
+        subsystems_analyzed=len(findings),
+    )
+    metadata["references_loaded"] = sorted(loaded_refs)
+
     report = AnalysisReport(
         plan=plan,
         findings=findings,
         cross_cutting_threats=cross_cutting,
         data_flow_diagram=data_flow_diagram,
-        metadata=_build_metadata(
-            models, plan, llm_calls=llm_calls, tool_calls=tool_calls,
-            subsystems_analyzed=len(findings),
-        ),
+        metadata=metadata,
     )
 
     total_threats = sum(len(f.threats) for f in findings) + len(cross_cutting)
@@ -286,6 +296,7 @@ def _analyze_subsystem(
     max_tool_calls: int,
     progress: ProgressCallback,
     call_counts: dict[str, int],
+    loaded_refs: set[str] | None = None,
 ) -> SubsystemFinding:
     """Analyze a single subsystem using the agent loop."""
     user_prompt = f"""Analyze the "{subsystem_name}" subsystem for STRIDE threats.
@@ -333,7 +344,7 @@ Start by reading the key files. Use grep to find security-relevant patterns like
                     )
                     progress.tool_call(tc.function_name, _brief_args(tc.arguments), cached=True)
                 else:
-                    result = execute_tool(target_path, tc)
+                    result = execute_tool(target_path, tc, loaded_refs=loaded_refs)
                     tool_cache[cache_key] = result
                     progress.tool_call(tc.function_name, _brief_args(tc.arguments), cached=False)
                 tool_calls += 1

--- a/stride_gpt/agent/persistence.py
+++ b/stride_gpt/agent/persistence.py
@@ -1,0 +1,375 @@
+"""Persist structured intermediates alongside an exported report.
+
+When the user passes ``-o <path>`` to /analyze or /quick, the report is the
+human-readable conclusion — but the intermediate state (planner output,
+per-subsystem findings, model/config metadata) is what an auditor or
+downstream consumer needs. This module captures those intermediates as JSON
+siblings next to the report:
+
+* ``<stem>.plan.json`` — the ``AnalysisPlan`` (analyze only)
+* ``<stem>.findings.json`` — the ``SubsystemFinding`` list + cross-cutting
+  threats + data flow diagram (analyze only)
+* ``<stem>.run.json`` — a ``RunManifest`` describing models, config, version,
+  and which reference cards the agent actually loaded (analyze and quick)
+
+The format flag (`-f`) controls only the report artefact; siblings are
+always JSON.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from stride_gpt.core.schemas import (
+    AnalysisPlan,
+    LLMConfig,
+    ModelPair,
+    Subsystem,
+    SubsystemFinding,
+)
+
+
+class ModelDescriptor(BaseModel):
+    """Just the bits of an LLMConfig that identify which model was used.
+
+    API keys and endpoints are deliberately excluded — a manifest will often
+    end up checked into git or attached to tickets, so it must not leak
+    credentials or per-deployment infrastructure detail.
+    """
+
+    provider: str
+    model_name: str
+
+    @classmethod
+    def from_llm_config(cls, config: LLMConfig) -> ModelDescriptor:
+        return cls(provider=config.provider, model_name=config.model_name)
+
+
+class RunManifest(BaseModel):
+    """Provenance for a single STRIDE-GPT run.
+
+    Captures the inputs that determine outputs (models, prompt, references)
+    plus enough environment metadata for an auditor to reason about the run
+    later. Designed to be safe to share — no API keys, no absolute paths
+    that leak filesystem layout.
+    """
+
+    stride_gpt_version: str
+    python_version: str
+    started_at: datetime
+    finished_at: datetime
+    architect: ModelDescriptor
+    worker: ModelDescriptor
+    detected_app_type: Literal["web", "genai", "agentic"]
+    # Where ``detected_app_type`` came from:
+    # ``"planner"`` — the architect classified the codebase
+    # ``"override:<value>"`` — user passed ``--app-type``
+    # ``"hint:<value>"`` — /quick was given an explicit hint
+    # ``"default"`` — /quick fell back to the default classification
+    app_type_source: str
+    # Redacted per ``redact_path``. For /quick this is the input filename
+    # or the literal ``"stdin"``.
+    target_path: str
+    target_git_sha: str | None
+    # sha256 hex over the prompt + model identities + reference catalogue.
+    # Lets two runs be compared at-a-glance: same hash ⇒ same inputs.
+    config_hash: str
+    # Names of reference cards the agent actually loaded during the run.
+    references_loaded: list[str]
+    mode: Literal["analyze", "quick"]
+
+
+# ---------------------------------------------------------------------------
+# Path redaction
+# ---------------------------------------------------------------------------
+
+
+def redact_path(p: Path | str) -> str:
+    """Return a serialisation-safe form of ``p``.
+
+    Manifests end up in git and tickets, so absolute paths that leak
+    ``/Users/<name>/...`` or ``/home/<name>/...`` are not acceptable. The
+    rule, applied in order:
+
+    1. If ``p`` resolves under the current working directory, return a
+       ``"./..."``-prefixed relative path.
+    2. Else if ``p`` resolves under ``$HOME``, return ``"~/..."``.
+    3. Else return the absolute path verbatim — rare; the user explicitly
+       pointed outside both anchors.
+    """
+    path = Path(p) if not isinstance(p, Path) else p
+    try:
+        resolved = path.resolve()
+    except OSError:
+        # An unresolvable path (e.g. ``"stdin"``) is returned untouched —
+        # /quick uses this with non-filesystem identifiers.
+        return str(p)
+
+    cwd = Path.cwd().resolve()
+    try:
+        rel = resolved.relative_to(cwd)
+        return "./" + str(rel) if str(rel) != "." else "./"
+    except ValueError:
+        pass
+
+    home_str = os.environ.get("HOME") or str(Path.home())
+    try:
+        home = Path(home_str).resolve()
+    except OSError:
+        home = None
+    if home is not None:
+        try:
+            rel = resolved.relative_to(home)
+            return "~/" + str(rel) if str(rel) != "." else "~/"
+        except ValueError:
+            pass
+
+    return str(resolved)
+
+
+# ---------------------------------------------------------------------------
+# Config hash
+# ---------------------------------------------------------------------------
+
+
+def _model_fingerprint(config: LLMConfig) -> dict[str, Any]:
+    """Subset of an LLMConfig that influences model output.
+
+    Excludes ``api_key``, ``api_base``, and ``timeout`` — those are
+    deployment noise, not model behaviour. Two runs with different keys
+    against the same model are functionally identical and should share a
+    ``config_hash``.
+    """
+    return {
+        "provider": config.provider,
+        "model_name": config.model_name,
+        "use_thinking": config.use_thinking,
+        "max_tokens": config.max_tokens,
+        "response_format": config.response_format,
+    }
+
+
+def compute_config_hash(
+    *, system_prompt: str, models: ModelPair, references: list[str]
+) -> str:
+    """sha256 over a stable canonical view of the run's input contract."""
+    payload = {
+        "system_prompt": system_prompt,
+        "worker": _model_fingerprint(models.worker),
+        "architect": (
+            _model_fingerprint(models.architect)
+            if models.architect is not None
+            else None
+        ),
+        "references": sorted(references),
+    }
+    canonical = json.dumps(payload, sort_keys=True, default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Git SHA discovery
+# ---------------------------------------------------------------------------
+
+
+def discover_git_sha(target: Path) -> str | None:
+    """Best-effort ``git rev-parse HEAD`` for ``target``.
+
+    Returns ``None`` when ``target`` isn't a git checkout, git isn't on
+    PATH, or the command fails for any other reason — provenance is a nice
+    to have, not load-bearing.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(target), "rev-parse", "HEAD"],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    sha = result.stdout.strip()
+    return sha or None
+
+
+# ---------------------------------------------------------------------------
+# Sibling writers
+# ---------------------------------------------------------------------------
+
+
+def _sibling_stem(output: Path) -> Path:
+    """Strip the last suffix from ``output`` to get the sibling-file stem."""
+    return output.with_suffix("") if output.suffix else output
+
+
+def _redact_subsystem(sub: Subsystem) -> Subsystem:
+    return sub.model_copy(update={"key_files": [redact_path(f) for f in sub.key_files]})
+
+
+def _redact_finding(finding: SubsystemFinding) -> SubsystemFinding:
+    return finding.model_copy(
+        update={"files_analyzed": [redact_path(f) for f in finding.files_analyzed]}
+    )
+
+
+def _write_json(path: Path, payload: str) -> None:
+    """Write ``payload`` to ``path`` with the project's trailing-newline convention."""
+    if not payload.endswith("\n"):
+        payload = payload + "\n"
+    path.write_text(payload)
+
+
+def write_intermediates(
+    output: Path,
+    *,
+    manifest: RunManifest,
+    plan: AnalysisPlan | None = None,
+    findings: list[SubsystemFinding] | None = None,
+    cross_cutting: list[dict[str, Any]] | None = None,
+    data_flow_diagram: str | None = None,
+) -> list[Path]:
+    """Persist JSON sibling artefacts next to ``output``.
+
+    The manifest is always written. The plan and findings siblings are
+    only written when their inputs are supplied (i.e. analyze runs);
+    /quick passes them as ``None`` and gets a manifest-only emission.
+
+    Path-bearing fields inside the findings file are passed through
+    :func:`redact_path` so a downstream consumer never has to re-redact.
+    The in-memory objects are not mutated — the auto-saved archive still
+    receives verbatim values.
+
+    Returns the list of paths written.
+    """
+    written: list[Path] = []
+    stem = _sibling_stem(output)
+
+    if plan is not None:
+        redacted_plan = plan.model_copy(
+            update={
+                "target_path": redact_path(plan.target_path),
+                "subsystems": [_redact_subsystem(s) for s in plan.subsystems],
+            }
+        )
+        plan_path = stem.with_suffix(".plan.json")
+        _write_json(plan_path, redacted_plan.model_dump_json(indent=2))
+        written.append(plan_path)
+
+    if findings is not None:
+        redacted_findings = [_redact_finding(f) for f in findings]
+        findings_payload = {
+            "findings": [f.model_dump() for f in redacted_findings],
+            "cross_cutting_threats": list(cross_cutting or []),
+            "data_flow_diagram": data_flow_diagram,
+        }
+        findings_path = stem.with_suffix(".findings.json")
+        _write_json(findings_path, json.dumps(findings_payload, indent=2))
+        written.append(findings_path)
+
+    run_path = stem.with_suffix(".run.json")
+    _write_json(run_path, manifest.model_dump_json(indent=2))
+    written.append(run_path)
+
+    return written
+
+
+# ---------------------------------------------------------------------------
+# Manifest assembly helpers
+# ---------------------------------------------------------------------------
+
+
+def _stride_gpt_version() -> str:
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        return version("stride-gpt")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _python_version() -> str:
+    import platform
+
+    return platform.python_version()
+
+
+def build_analyze_manifest(
+    *,
+    models: ModelPair,
+    plan: AnalysisPlan,
+    target: Path,
+    started_at: datetime,
+    finished_at: datetime,
+    app_type_source: str,
+    system_prompt: str,
+    references_loaded: list[str],
+) -> RunManifest:
+    """Assemble the manifest for a /analyze run."""
+    return RunManifest(
+        stride_gpt_version=_stride_gpt_version(),
+        python_version=_python_version(),
+        started_at=started_at,
+        finished_at=finished_at,
+        architect=ModelDescriptor.from_llm_config(models.for_architect()),
+        worker=ModelDescriptor.from_llm_config(models.worker),
+        detected_app_type=plan.detected_app_type,
+        app_type_source=app_type_source,
+        target_path=redact_path(target),
+        target_git_sha=discover_git_sha(target),
+        config_hash=compute_config_hash(
+            system_prompt=system_prompt,
+            models=models,
+            references=references_loaded,
+        ),
+        references_loaded=sorted(references_loaded),
+        mode="analyze",
+    )
+
+
+def build_quick_manifest(
+    *,
+    models: ModelPair,
+    target_label: str,
+    detected_app_type: Literal["web", "genai", "agentic"],
+    app_type_source: str,
+    started_at: datetime,
+    finished_at: datetime,
+    system_prompt: str,
+    references_loaded: list[str],
+) -> RunManifest:
+    """Assemble the manifest for a /quick run.
+
+    ``target_label`` is the input filename (when ``-i`` is used) or the
+    literal ``"stdin"`` — /quick has no codebase target, so the redaction
+    rule doesn't apply to a filesystem path here.
+    """
+    return RunManifest(
+        stride_gpt_version=_stride_gpt_version(),
+        python_version=_python_version(),
+        started_at=started_at,
+        finished_at=finished_at,
+        architect=ModelDescriptor.from_llm_config(models.for_architect()),
+        worker=ModelDescriptor.from_llm_config(models.worker),
+        detected_app_type=detected_app_type,
+        app_type_source=app_type_source,
+        target_path=target_label,
+        target_git_sha=None,
+        config_hash=compute_config_hash(
+            system_prompt=system_prompt,
+            models=models,
+            references=references_loaded,
+        ),
+        references_loaded=sorted(references_loaded),
+        mode="quick",
+    )

--- a/stride_gpt/agent/persistence.py
+++ b/stride_gpt/agent/persistence.py
@@ -10,7 +10,9 @@ siblings next to the report:
 * ``<stem>.findings.json`` — the ``SubsystemFinding`` list + cross-cutting
   threats + data flow diagram (analyze only)
 * ``<stem>.run.json`` — a ``RunManifest`` describing models, config, version,
-  and which reference cards the agent actually loaded (analyze and quick)
+  which reference cards the agent actually loaded, and a ``run_summary``
+  recording whether the run completed or a call cap truncated it (analyze
+  and quick)
 
 The format flag (`-f`) controls only the report artefact; siblings are
 always JSON.
@@ -53,6 +55,29 @@ class ModelDescriptor(BaseModel):
         return cls(provider=config.provider, model_name=config.model_name)
 
 
+class RunSummary(BaseModel):
+    """Completeness of a run, so the intermediates are self-describing.
+
+    Without this, an auditor reading ``findings.json`` in isolation can't
+    tell a full analysis from one a call/tool cap cut short — a truncated
+    run and a complete one look identical. ``status`` is:
+
+    * ``"completed"`` — every planned subsystem was reached (analyze), or the
+      single-shot model returned (quick).
+    * ``"partial"`` — a call/tool cap stopped /analyze before every planned
+      subsystem was reached (``subsystems_analyzed < subsystems_planned``).
+
+    ``subsystems_planned`` / ``subsystems_analyzed`` are ``None`` for /quick,
+    which has no per-subsystem phase.
+    """
+
+    status: Literal["completed", "partial"]
+    subsystems_planned: int | None = None
+    subsystems_analyzed: int | None = None
+    llm_calls: int
+    tool_calls: int
+
+
 class RunManifest(BaseModel):
     """Provenance for a single STRIDE-GPT run.
 
@@ -84,6 +109,9 @@ class RunManifest(BaseModel):
     config_hash: str
     # Names of reference cards the agent actually loaded during the run.
     references_loaded: list[str]
+    # Outcome / coverage of the run — distinguishes a complete analysis from
+    # one a call cap truncated.
+    run_summary: RunSummary
     mode: Literal["analyze", "quick"]
 
 
@@ -314,8 +342,24 @@ def build_analyze_manifest(
     app_type_source: str,
     system_prompt: str,
     references_loaded: list[str],
+    llm_calls: int,
+    tool_calls: int,
+    subsystems_analyzed: int,
 ) -> RunManifest:
-    """Assemble the manifest for a /analyze run."""
+    """Assemble the manifest for a /analyze run.
+
+    ``subsystems_analyzed`` is the number of subsystems that produced a
+    finding; when it's below the planned count a call/tool cap truncated the
+    run and ``run_summary.status`` is reported as ``"partial"``.
+    """
+    subsystems_planned = len(plan.subsystems)
+    run_summary = RunSummary(
+        status="partial" if subsystems_analyzed < subsystems_planned else "completed",
+        subsystems_planned=subsystems_planned,
+        subsystems_analyzed=subsystems_analyzed,
+        llm_calls=llm_calls,
+        tool_calls=tool_calls,
+    )
     return RunManifest(
         stride_gpt_version=_stride_gpt_version(),
         python_version=_python_version(),
@@ -333,6 +377,7 @@ def build_analyze_manifest(
             references=references_loaded,
         ),
         references_loaded=sorted(references_loaded),
+        run_summary=run_summary,
         mode="analyze",
     )
 
@@ -347,13 +392,25 @@ def build_quick_manifest(
     finished_at: datetime,
     system_prompt: str,
     references_loaded: list[str],
+    llm_calls: int,
+    tool_calls: int,
 ) -> RunManifest:
     """Assemble the manifest for a /quick run.
 
     ``target_label`` is the input filename (when ``-i`` is used) or the
     literal ``"stdin"`` — /quick has no codebase target, so the redaction
     rule doesn't apply to a filesystem path here.
+
+    /quick is single-shot with no per-subsystem phase, so ``run_summary``
+    always reports ``"completed"`` with ``None`` subsystem counts.
     """
+    run_summary = RunSummary(
+        status="completed",
+        subsystems_planned=None,
+        subsystems_analyzed=None,
+        llm_calls=llm_calls,
+        tool_calls=tool_calls,
+    )
     return RunManifest(
         stride_gpt_version=_stride_gpt_version(),
         python_version=_python_version(),
@@ -371,5 +428,6 @@ def build_quick_manifest(
             references=references_loaded,
         ),
         references_loaded=sorted(references_loaded),
+        run_summary=run_summary,
         mode="quick",
     )

--- a/stride_gpt/agent/quick.py
+++ b/stride_gpt/agent/quick.py
@@ -66,6 +66,10 @@ def run_quick_analysis(
     # Cache load_reference results so the model doesn't waste turns calling
     # the same card twice. Card content is idempotent so the cache is safe.
     tool_cache: dict[str, str] = {}
+    # Names the agent loads via the ``load_reference`` tool. Surfaced on the
+    # returned ``ThreatModelOutput`` so the run manifest can record which
+    # cards actually shaped the output.
+    loaded_refs: set[str] = set()
 
     target_path = Path("/")  # load_reference ignores the root parameter
 
@@ -92,7 +96,7 @@ def run_quick_analysis(
                         "earlier tool response instead of requesting it again."
                     )
                 else:
-                    result = execute_tool(target_path, tc)
+                    result = execute_tool(target_path, tc, loaded_refs=loaded_refs)
                     tool_cache[key] = result
                 tool_calls += 1
                 tools_used[tc.function_name] = tools_used.get(tc.function_name, 0) + 1
@@ -110,7 +114,7 @@ def run_quick_analysis(
             # JSON parse failed — one retry with forced JSON mode.
             parsed = _retry_as_json(models.worker, messages)
             llm_calls += 1
-        return _attach_counts(parsed, llm_calls, tool_calls, tools_used)
+        return _attach_counts(parsed, llm_calls, tool_calls, tools_used, loaded_refs)
 
     # Hit the call cap before getting a final JSON — coerce one last attempt.
     messages.append({
@@ -123,7 +127,7 @@ def run_quick_analysis(
     })
     parsed = _retry_as_json(models.worker, messages)
     llm_calls += 1
-    return _attach_counts(parsed, llm_calls, tool_calls, tools_used)
+    return _attach_counts(parsed, llm_calls, tool_calls, tools_used, loaded_refs)
 
 
 def _attach_counts(
@@ -131,10 +135,12 @@ def _attach_counts(
     llm_calls: int,
     tool_calls: int,
     tools_used: dict[str, int],
+    loaded_refs: set[str],
 ) -> ThreatModelOutput:
     output.llm_calls = llm_calls
     output.tool_calls = tool_calls
     output.tools_used = tools_used
+    output.references_loaded = sorted(loaded_refs)
     return output
 
 

--- a/stride_gpt/agent/tools.py
+++ b/stride_gpt/agent/tools.py
@@ -342,12 +342,34 @@ _TOOL_DISPATCH = {
 }
 
 
-def execute_tool(root: Path, tool_call: ToolCallResult) -> str:
-    """Execute a tool call and return the result as a string."""
+def execute_tool(
+    root: Path,
+    tool_call: ToolCallResult,
+    *,
+    loaded_refs: set[str] | None = None,
+) -> str:
+    """Execute a tool call and return the result as a string.
+
+    When ``loaded_refs`` is passed, every successful ``load_reference`` call
+    appends its ``name`` argument to the set so the run manifest can record
+    which cards the agent actually loaded. Failed loads (the loader returns
+    a string starting with ``"Error:"``) are not counted.
+    """
     handler = _TOOL_DISPATCH.get(tool_call.function_name)
     if handler is None:
         return f"Error: unknown tool '{tool_call.function_name}'"
     try:
-        return handler(root, tool_call.arguments)
+        result = handler(root, tool_call.arguments)
     except Exception as e:
         return f"Error executing {tool_call.function_name}: {e}"
+
+    if (
+        loaded_refs is not None
+        and tool_call.function_name == "load_reference"
+        and not result.startswith("Error:")
+    ):
+        name = tool_call.arguments.get("name")
+        if isinstance(name, str) and name:
+            loaded_refs.add(name)
+
+    return result

--- a/stride_gpt/cli.py
+++ b/stride_gpt/cli.py
@@ -4,9 +4,18 @@ from __future__ import annotations
 
 import json
 import sys
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import TYPE_CHECKING, Annotated, Optional
+
+if TYPE_CHECKING:
+    from stride_gpt.core.schemas import (
+        AnalysisPlan,
+        AnalysisReport,
+        ModelPair,
+        ThreatModelOutput,
+    )
 
 from dotenv import load_dotenv
 
@@ -188,6 +197,87 @@ def _handle_config(config: dict) -> None:
             console.print("[dim]Keeping existing configuration.[/dim]")
 
 
+def _persist_analyze_intermediates(
+    *,
+    output: Path,
+    target: Path,
+    models: ModelPair,
+    plan: AnalysisPlan,
+    report: AnalysisReport,
+    started_at: datetime,
+    finished_at: datetime,
+    app_type_source: str,
+) -> None:
+    """Write plan/findings/run.json siblings next to a /analyze -o report.
+
+    No-op for cancelled runs — matches the existing skip of save_report.
+    """
+    if report.metadata.get("status") == "cancelled":
+        return
+
+    from stride_gpt.agent.persistence import (
+        build_analyze_manifest,
+        write_intermediates,
+    )
+    from stride_gpt.core.prompts import base_system_prompt
+
+    refs = report.metadata.get("references_loaded", []) or []
+    manifest = build_analyze_manifest(
+        models=models,
+        plan=plan,
+        target=target,
+        started_at=started_at,
+        finished_at=finished_at,
+        app_type_source=app_type_source,
+        system_prompt=base_system_prompt(),
+        references_loaded=refs,
+    )
+    written = write_intermediates(
+        output,
+        manifest=manifest,
+        plan=plan,
+        findings=report.findings,
+        cross_cutting=report.cross_cutting_threats,
+        data_flow_diagram=report.data_flow_diagram,
+    )
+    for path in written:
+        console.print(f"[green]Intermediate written to {path}[/green]")
+
+
+def _persist_quick_intermediates(
+    *,
+    output: Path,
+    target_label: str,
+    models: ModelPair,
+    result: ThreatModelOutput,
+    started_at: datetime,
+    finished_at: datetime,
+    hint: str | None,
+) -> None:
+    """Write the run.json sibling next to a /quick -o report."""
+    from stride_gpt.agent.persistence import (
+        build_quick_manifest,
+        write_intermediates,
+    )
+    from stride_gpt.core.prompts import coerce_app_type, quick_base_prompt
+
+    detected = coerce_app_type(hint)
+    app_type_source = f"hint:{hint}" if hint else "default"
+    manifest = build_quick_manifest(
+        models=models,
+        target_label=target_label,
+        detected_app_type=detected,
+        app_type_source=app_type_source,
+        started_at=started_at,
+        finished_at=finished_at,
+        system_prompt=quick_base_prompt(),
+        references_loaded=result.references_loaded,
+    )
+    written = write_intermediates(output, manifest=manifest)
+    for path in written:
+        console.print(f"[green]Intermediate written to {path}[/green]")
+
+
 def _handle_analyze(config: dict, args_str: str) -> None:
     """Run agentic analysis from interactive session."""
     from stride_gpt.agent.html_report import render_html
@@ -240,6 +330,7 @@ def _handle_analyze(config: dict, args_str: str) -> None:
     progress = RichProgress(console)
 
     # Phase 1: Plan
+    started_at = datetime.now(timezone.utc)
     progress.phase_start("Phase 1", "Planning")
     progress.status("Scanning codebase and generating plan...")
     plan = create_analysis_plan(models, target_path)
@@ -258,6 +349,7 @@ def _handle_analyze(config: dict, args_str: str) -> None:
         plan=plan,
         progress=progress,
     )
+    finished_at = datetime.now(timezone.utc)
 
     # Auto-save (skip cancelled runs)
     saved_path = None
@@ -283,6 +375,16 @@ def _handle_analyze(config: dict, args_str: str) -> None:
             html_path = output_path.with_suffix(".html")
             html_path.write_text(render_html(report))
             console.print(f"[green]HTML view written to {html_path}[/green]")
+        _persist_analyze_intermediates(
+            output=output_path,
+            target=target_path,
+            models=models,
+            plan=plan,
+            report=report,
+            started_at=started_at,
+            finished_at=finished_at,
+            app_type_source="planner",
+        )
     else:
         console.print()
         if output_format == OutputFormat.markdown:
@@ -514,8 +616,10 @@ def _handle_quick(config: dict, args_str: str) -> None:
         )
     )
 
+    started_at = datetime.now(timezone.utc)
     with console.status("Analysing description..."):
         result = run_quick_analysis(models, app_description, hint=hint)
+    finished_at = datetime.now(timezone.utc)
 
     saved_path = save_quick_report(
         result,
@@ -536,6 +640,15 @@ def _handle_quick(config: dict, args_str: str) -> None:
         else:
             output_path.write_text(markdown)
         console.print(f"[green]Report written to {output_path}[/green]")
+        _persist_quick_intermediates(
+            output=output_path,
+            target_label=str(input_file) if input_file else "stdin",
+            models=models,
+            result=result,
+            started_at=started_at,
+            finished_at=finished_at,
+            hint=hint,
+        )
     else:
         console.print()
         console.print(Markdown(markdown))
@@ -622,6 +735,7 @@ def analyze(
     progress = RichProgress(console)
 
     # Phase 1: Plan
+    started_at = datetime.now(timezone.utc)
     progress.phase_start("Phase 1", "Planning")
     progress.status("Scanning codebase and generating plan...")
     plan = create_analysis_plan(models, target)
@@ -652,6 +766,7 @@ def analyze(
         max_tool_calls=max_tool_calls,
         progress=progress,
     )
+    finished_at = datetime.now(timezone.utc)
 
     # Auto-save
     saved_path = None
@@ -674,6 +789,21 @@ def analyze(
             html_path = output.with_suffix(".html")
             html_path.write_text(render_html(report))
             console.print(f"[green]HTML view written to {html_path}[/green]")
+        app_type_source = (
+            f"override:{app_type.value}"
+            if app_type != AppTypeOverride.auto
+            else "planner"
+        )
+        _persist_analyze_intermediates(
+            output=output,
+            target=target,
+            models=models,
+            plan=plan,
+            report=report,
+            started_at=started_at,
+            finished_at=finished_at,
+            app_type_source=app_type_source,
+        )
     else:
         console.print()
         if output_format == OutputFormat.markdown:
@@ -755,8 +885,10 @@ def quick(
         )
     )
 
+    started_at = datetime.now(timezone.utc)
     with console.status("Analysing description..."):
         result = run_quick_analysis(models, app_description, hint=app_type)
+    finished_at = datetime.now(timezone.utc)
 
     saved_path = save_quick_report(
         result,
@@ -774,6 +906,15 @@ def quick(
         else:
             output.write_text(markdown)
         console.print(f"[green]Report written to {output}[/green]")
+        _persist_quick_intermediates(
+            output=output,
+            target_label=str(input_file) if input_file else "stdin",
+            models=models,
+            result=result,
+            started_at=started_at,
+            finished_at=finished_at,
+            hint=app_type,
+        )
     else:
         console.print()
         console.print(Markdown(markdown))

--- a/stride_gpt/cli.py
+++ b/stride_gpt/cli.py
@@ -231,6 +231,11 @@ def _persist_analyze_intermediates(
         app_type_source=app_type_source,
         system_prompt=base_system_prompt(),
         references_loaded=refs,
+        llm_calls=report.metadata.get("llm_calls", 0),
+        tool_calls=report.metadata.get("tool_calls", 0),
+        subsystems_analyzed=report.metadata.get(
+            "subsystems_analyzed", len(report.findings)
+        ),
     )
     written = write_intermediates(
         output,
@@ -272,6 +277,8 @@ def _persist_quick_intermediates(
         finished_at=finished_at,
         system_prompt=quick_base_prompt(),
         references_loaded=result.references_loaded,
+        llm_calls=result.llm_calls,
+        tool_calls=result.tool_calls,
     )
     written = write_intermediates(output, manifest=manifest)
     for path in written:

--- a/stride_gpt/core/schemas.py
+++ b/stride_gpt/core/schemas.py
@@ -50,6 +50,10 @@ class ThreatModelOutput:
     llm_calls: int = 0
     tool_calls: int = 0
     tools_used: dict[str, int] = field(default_factory=dict)
+    # Names of reference cards the agent loaded via ``load_reference``.
+    # Populated by the /quick agent loop so the run manifest can record
+    # which cards actually shaped the output.
+    references_loaded: list[str] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,385 @@
+"""Tests for the intermediate persistence layer (issue #122)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from stride_gpt.agent.persistence import (
+    ModelDescriptor,
+    RunManifest,
+    build_analyze_manifest,
+    build_quick_manifest,
+    compute_config_hash,
+    redact_path,
+    write_intermediates,
+)
+from stride_gpt.core.schemas import (
+    LLMConfig,
+    ModelPair,
+    SubsystemFinding,
+)
+
+# ---------------------------------------------------------------------------
+# redact_path
+# ---------------------------------------------------------------------------
+
+
+def test_redact_path_under_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    nested = tmp_path / "services" / "auth"
+    nested.mkdir(parents=True)
+    assert redact_path(nested) == "./services/auth"
+
+
+def test_redact_path_cwd_itself(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    assert redact_path(tmp_path) == "./"
+
+
+def test_redact_path_under_home_outside_cwd(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    cwd = tmp_path / "elsewhere"
+    cwd.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(cwd)
+    target = home / "code" / "acme"
+    target.mkdir(parents=True)
+    assert redact_path(target) == "~/code/acme"
+
+
+def test_redact_path_outside_cwd_and_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    other = tmp_path / "other"
+    other.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(cwd)
+    # Not under cwd, not under HOME — falls through to absolute path.
+    assert redact_path(other) == str(other.resolve())
+
+
+# ---------------------------------------------------------------------------
+# compute_config_hash
+# ---------------------------------------------------------------------------
+
+
+def _make_pair(
+    worker_model: str = "claude-sonnet-4-5",
+    api_key: str = "sk-test",
+) -> ModelPair:
+    return ModelPair(
+        worker=LLMConfig(
+            provider="Anthropic API", model_name=worker_model, api_key=api_key,
+        ),
+    )
+
+
+def test_config_hash_is_deterministic():
+    pair = _make_pair()
+    a = compute_config_hash(system_prompt="P", models=pair, references=["genai"])
+    b = compute_config_hash(system_prompt="P", models=pair, references=["genai"])
+    assert a == b
+
+
+def test_config_hash_changes_with_prompt():
+    pair = _make_pair()
+    a = compute_config_hash(system_prompt="P", models=pair, references=[])
+    b = compute_config_hash(system_prompt="P2", models=pair, references=[])
+    assert a != b
+
+
+def test_config_hash_changes_with_model():
+    a = compute_config_hash(
+        system_prompt="P", models=_make_pair("claude-sonnet-4-5"), references=[],
+    )
+    b = compute_config_hash(
+        system_prompt="P", models=_make_pair("claude-opus-4-7"), references=[],
+    )
+    assert a != b
+
+
+def test_config_hash_changes_with_references():
+    pair = _make_pair()
+    a = compute_config_hash(system_prompt="P", models=pair, references=["genai"])
+    b = compute_config_hash(system_prompt="P", models=pair, references=["agentic"])
+    assert a != b
+
+
+def test_config_hash_ignores_api_key():
+    # Two runs against the same model with different BYOK keys should share
+    # a hash — the key is deployment noise, not behaviour.
+    a = compute_config_hash(
+        system_prompt="P", models=_make_pair(api_key="key-A"), references=[],
+    )
+    b = compute_config_hash(
+        system_prompt="P", models=_make_pair(api_key="key-B"), references=[],
+    )
+    assert a == b
+
+
+def test_config_hash_reference_order_insensitive():
+    pair = _make_pair()
+    a = compute_config_hash(
+        system_prompt="P", models=pair, references=["genai", "agentic"],
+    )
+    b = compute_config_hash(
+        system_prompt="P", models=pair, references=["agentic", "genai"],
+    )
+    assert a == b
+
+
+# ---------------------------------------------------------------------------
+# write_intermediates — analyze run
+# ---------------------------------------------------------------------------
+
+
+def _make_analyze_manifest(tmp_path: Path) -> RunManifest:
+    return RunManifest(
+        stride_gpt_version="0.0.0-test",
+        python_version="3.12.0",
+        started_at=datetime.now(UTC),
+        finished_at=datetime.now(UTC),
+        architect=ModelDescriptor(provider="A", model_name="m1"),
+        worker=ModelDescriptor(provider="A", model_name="m2"),
+        detected_app_type="web",
+        app_type_source="planner",
+        target_path="./",
+        target_git_sha=None,
+        config_hash="0" * 64,
+        references_loaded=["genai"],
+        mode="analyze",
+    )
+
+
+def test_write_intermediates_analyze_emits_three_siblings(
+    tmp_path, sample_plan, sample_finding, sample_report,
+):
+    output = tmp_path / "report.md"
+    output.write_text("# placeholder report\n")
+
+    paths = write_intermediates(
+        output,
+        manifest=_make_analyze_manifest(tmp_path),
+        plan=sample_plan,
+        findings=sample_report.findings,
+        cross_cutting=sample_report.cross_cutting_threats,
+        data_flow_diagram=sample_report.data_flow_diagram,
+    )
+
+    plan_path = tmp_path / "report.plan.json"
+    findings_path = tmp_path / "report.findings.json"
+    run_path = tmp_path / "report.run.json"
+
+    assert set(paths) == {plan_path, findings_path, run_path}
+    for p in paths:
+        assert p.is_file()
+
+
+def test_write_intermediates_analyze_files_parse_as_models(
+    tmp_path, sample_plan, sample_report,
+):
+    output = tmp_path / "audit.sarif"
+    output.write_text("{}")
+    write_intermediates(
+        output,
+        manifest=_make_analyze_manifest(tmp_path),
+        plan=sample_plan,
+        findings=sample_report.findings,
+        cross_cutting=sample_report.cross_cutting_threats,
+        data_flow_diagram=sample_report.data_flow_diagram,
+    )
+
+    from stride_gpt.core.schemas import AnalysisPlan
+
+    plan_data = json.loads((tmp_path / "audit.plan.json").read_text())
+    AnalysisPlan(**plan_data)  # round-trip via pydantic
+
+    findings_data = json.loads((tmp_path / "audit.findings.json").read_text())
+    assert "findings" in findings_data
+    assert "cross_cutting_threats" in findings_data
+    assert "data_flow_diagram" in findings_data
+    for f in findings_data["findings"]:
+        SubsystemFinding(**f)
+
+    run_data = json.loads((tmp_path / "audit.run.json").read_text())
+    RunManifest(**run_data)
+
+
+def test_write_intermediates_format_flag_does_not_change_sibling_extensions(
+    tmp_path, sample_plan, sample_report,
+):
+    # Three different report formats — same three sibling filenames.
+    for ext in (".md", ".sarif", ".json", ".html"):
+        sub = tmp_path / ext.lstrip(".")
+        sub.mkdir()
+        output = sub / f"r{ext}"
+        output.write_text("ignored")
+        write_intermediates(
+            output,
+            manifest=_make_analyze_manifest(tmp_path),
+            plan=sample_plan,
+            findings=sample_report.findings,
+            cross_cutting=sample_report.cross_cutting_threats,
+            data_flow_diagram=sample_report.data_flow_diagram,
+        )
+        assert (sub / "r.plan.json").is_file()
+        assert (sub / "r.findings.json").is_file()
+        assert (sub / "r.run.json").is_file()
+
+
+# ---------------------------------------------------------------------------
+# write_intermediates — quick run
+# ---------------------------------------------------------------------------
+
+
+def _make_quick_manifest() -> RunManifest:
+    return RunManifest(
+        stride_gpt_version="0.0.0-test",
+        python_version="3.12.0",
+        started_at=datetime.now(UTC),
+        finished_at=datetime.now(UTC),
+        architect=ModelDescriptor(provider="A", model_name="m1"),
+        worker=ModelDescriptor(provider="A", model_name="m2"),
+        detected_app_type="genai",
+        app_type_source="hint:genai",
+        target_path="stdin",
+        target_git_sha=None,
+        config_hash="f" * 64,
+        references_loaded=[],
+        mode="quick",
+    )
+
+
+def test_write_intermediates_quick_only_emits_run_json(tmp_path):
+    output = tmp_path / "quick.md"
+    output.write_text("# placeholder")
+
+    paths = write_intermediates(output, manifest=_make_quick_manifest())
+
+    assert paths == [tmp_path / "quick.run.json"]
+    assert not (tmp_path / "quick.plan.json").exists()
+    assert not (tmp_path / "quick.findings.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Path redaction inside findings.json
+# ---------------------------------------------------------------------------
+
+
+def test_findings_paths_are_redacted_on_disk(tmp_path, monkeypatch, sample_plan):
+    monkeypatch.chdir(tmp_path)
+    inside_cwd = tmp_path / "src" / "auth.py"
+    inside_cwd.parent.mkdir(parents=True)
+    inside_cwd.write_text("# auth")
+
+    finding = SubsystemFinding(
+        subsystem="Auth",
+        threats=[],
+        improvement_suggestions=[],
+        files_analyzed=[str(inside_cwd.resolve())],
+    )
+
+    output = tmp_path / "report.md"
+    output.write_text("ignored")
+    write_intermediates(
+        output,
+        manifest=_make_analyze_manifest(tmp_path),
+        plan=sample_plan,
+        findings=[finding],
+        cross_cutting=[],
+        data_flow_diagram=None,
+    )
+
+    findings_data = json.loads((tmp_path / "report.findings.json").read_text())
+    on_disk = findings_data["findings"][0]["files_analyzed"][0]
+    assert on_disk == "./src/auth.py"
+
+    # The original finding wasn't mutated.
+    assert finding.files_analyzed[0] == str(inside_cwd.resolve())
+
+
+# ---------------------------------------------------------------------------
+# RunManifest round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_run_manifest_round_trip():
+    original = RunManifest(
+        stride_gpt_version="1.2.3",
+        python_version="3.12.0",
+        started_at=datetime(2026, 6, 15, 12, 0, tzinfo=UTC),
+        finished_at=datetime(2026, 6, 15, 12, 5, tzinfo=UTC),
+        architect=ModelDescriptor(provider="Anthropic API", model_name="opus"),
+        worker=ModelDescriptor(provider="Anthropic API", model_name="sonnet"),
+        detected_app_type="agentic",
+        app_type_source="override:agentic",
+        target_path="./",
+        target_git_sha="abc123",
+        config_hash="a" * 64,
+        references_loaded=["agentic", "genai"],
+        mode="analyze",
+    )
+    # JSON round-trip: model_dump_json → load → RunManifest(**) reproduces.
+    rehydrated = RunManifest(**json.loads(original.model_dump_json()))
+    assert rehydrated == original
+
+
+# ---------------------------------------------------------------------------
+# Manifest builders
+# ---------------------------------------------------------------------------
+
+
+def test_build_analyze_manifest_populates_expected_fields(
+    tmp_path, monkeypatch, sample_plan, model_pair,
+):
+    monkeypatch.chdir(tmp_path)
+    started = datetime(2026, 6, 15, 12, 0, tzinfo=UTC)
+    finished = datetime(2026, 6, 15, 12, 5, tzinfo=UTC)
+
+    manifest = build_analyze_manifest(
+        models=model_pair,
+        plan=sample_plan,
+        target=tmp_path,
+        started_at=started,
+        finished_at=finished,
+        app_type_source="planner",
+        system_prompt="hello",
+        references_loaded=["genai"],
+    )
+
+    assert manifest.mode == "analyze"
+    assert manifest.detected_app_type == sample_plan.detected_app_type
+    assert manifest.app_type_source == "planner"
+    assert manifest.target_path == "./"
+    assert manifest.references_loaded == ["genai"]
+    assert manifest.worker.provider == model_pair.worker.provider
+    assert manifest.worker.model_name == model_pair.worker.model_name
+    assert manifest.started_at == started
+    assert manifest.finished_at == finished
+    # 64-char sha256 hex.
+    assert len(manifest.config_hash) == 64
+    int(manifest.config_hash, 16)
+
+
+def test_build_quick_manifest_uses_target_label_verbatim(model_pair):
+    manifest = build_quick_manifest(
+        models=model_pair,
+        target_label="my-app.md",
+        detected_app_type="genai",
+        app_type_source="hint:genai",
+        started_at=datetime.now(UTC),
+        finished_at=datetime.now(UTC),
+        system_prompt="quick prompt",
+        references_loaded=["genai", "agentic"],
+    )
+
+    assert manifest.mode == "quick"
+    assert manifest.target_path == "my-app.md"
+    assert manifest.target_git_sha is None
+    # references_loaded is sorted by the builder.
+    assert manifest.references_loaded == ["agentic", "genai"]

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from stride_gpt.agent.persistence import (
     ModelDescriptor,
     RunManifest,
+    RunSummary,
     build_analyze_manifest,
     build_quick_manifest,
     compute_config_hash,
@@ -152,6 +153,13 @@ def _make_analyze_manifest(tmp_path: Path) -> RunManifest:
         target_git_sha=None,
         config_hash="0" * 64,
         references_loaded=["genai"],
+        run_summary=RunSummary(
+            status="completed",
+            subsystems_planned=2,
+            subsystems_analyzed=2,
+            llm_calls=5,
+            tool_calls=12,
+        ),
         mode="analyze",
     )
 
@@ -251,6 +259,13 @@ def _make_quick_manifest() -> RunManifest:
         target_git_sha=None,
         config_hash="f" * 64,
         references_loaded=[],
+        run_summary=RunSummary(
+            status="completed",
+            subsystems_planned=None,
+            subsystems_analyzed=None,
+            llm_calls=3,
+            tool_calls=1,
+        ),
         mode="quick",
     )
 
@@ -322,6 +337,13 @@ def test_run_manifest_round_trip():
         target_git_sha="abc123",
         config_hash="a" * 64,
         references_loaded=["agentic", "genai"],
+        run_summary=RunSummary(
+            status="partial",
+            subsystems_planned=5,
+            subsystems_analyzed=1,
+            llm_calls=8,
+            tool_calls=8,
+        ),
         mode="analyze",
     )
     # JSON round-trip: model_dump_json → load → RunManifest(**) reproduces.
@@ -350,6 +372,9 @@ def test_build_analyze_manifest_populates_expected_fields(
         app_type_source="planner",
         system_prompt="hello",
         references_loaded=["genai"],
+        llm_calls=5,
+        tool_calls=12,
+        subsystems_analyzed=len(sample_plan.subsystems),
     )
 
     assert manifest.mode == "analyze"
@@ -366,6 +391,55 @@ def test_build_analyze_manifest_populates_expected_fields(
     int(manifest.config_hash, 16)
 
 
+def test_build_analyze_manifest_status_completed_when_all_subsystems_analyzed(
+    tmp_path, monkeypatch, sample_plan, model_pair,
+):
+    monkeypatch.chdir(tmp_path)
+    manifest = build_analyze_manifest(
+        models=model_pair,
+        plan=sample_plan,
+        target=tmp_path,
+        started_at=datetime.now(UTC),
+        finished_at=datetime.now(UTC),
+        app_type_source="planner",
+        system_prompt="hello",
+        references_loaded=[],
+        llm_calls=5,
+        tool_calls=12,
+        subsystems_analyzed=len(sample_plan.subsystems),
+    )
+
+    assert manifest.run_summary.status == "completed"
+    assert manifest.run_summary.subsystems_planned == len(sample_plan.subsystems)
+    assert manifest.run_summary.subsystems_analyzed == len(sample_plan.subsystems)
+    assert manifest.run_summary.llm_calls == 5
+    assert manifest.run_summary.tool_calls == 12
+
+
+def test_build_analyze_manifest_status_partial_when_cap_truncates(
+    tmp_path, monkeypatch, sample_plan, model_pair,
+):
+    # A call cap stopped analysis after 1 of the plan's 2 subsystems.
+    monkeypatch.chdir(tmp_path)
+    manifest = build_analyze_manifest(
+        models=model_pair,
+        plan=sample_plan,
+        target=tmp_path,
+        started_at=datetime.now(UTC),
+        finished_at=datetime.now(UTC),
+        app_type_source="planner",
+        system_prompt="hello",
+        references_loaded=[],
+        llm_calls=8,
+        tool_calls=8,
+        subsystems_analyzed=1,
+    )
+
+    assert manifest.run_summary.status == "partial"
+    assert manifest.run_summary.subsystems_planned == 2
+    assert manifest.run_summary.subsystems_analyzed == 1
+
+
 def test_build_quick_manifest_uses_target_label_verbatim(model_pair):
     manifest = build_quick_manifest(
         models=model_pair,
@@ -376,6 +450,8 @@ def test_build_quick_manifest_uses_target_label_verbatim(model_pair):
         finished_at=datetime.now(UTC),
         system_prompt="quick prompt",
         references_loaded=["genai", "agentic"],
+        llm_calls=3,
+        tool_calls=1,
     )
 
     assert manifest.mode == "quick"
@@ -383,3 +459,25 @@ def test_build_quick_manifest_uses_target_label_verbatim(model_pair):
     assert manifest.target_git_sha is None
     # references_loaded is sorted by the builder.
     assert manifest.references_loaded == ["agentic", "genai"]
+
+
+def test_build_quick_manifest_run_summary_completed_with_null_subsystems(model_pair):
+    # /quick is single-shot: always "completed", no subsystem counts.
+    manifest = build_quick_manifest(
+        models=model_pair,
+        target_label="stdin",
+        detected_app_type="web",
+        app_type_source="default",
+        started_at=datetime.now(UTC),
+        finished_at=datetime.now(UTC),
+        system_prompt="quick prompt",
+        references_loaded=[],
+        llm_calls=4,
+        tool_calls=2,
+    )
+
+    assert manifest.run_summary.status == "completed"
+    assert manifest.run_summary.subsystems_planned is None
+    assert manifest.run_summary.subsystems_analyzed is None
+    assert manifest.run_summary.llm_calls == 4
+    assert manifest.run_summary.tool_calls == 2


### PR DESCRIPTION
## What

Persists structured JSON intermediates alongside an exported report so auditors and downstream tools get the run's provenance, not just the human-readable conclusion. Closes #122.

When `-o <path>` is passed to `/analyze` or `/quick`, JSON siblings are written next to the report:

- `<stem>.plan.json` — the `AnalysisPlan` (analyze only)
- `<stem>.findings.json` — subsystem findings, cross-cutting threats, and the data flow diagram (analyze only)
- `<stem>.run.json` — a `RunManifest`: models, config hash, version, timing, which reference cards the agent actually loaded, and a `run_summary` recording whether the run completed or a call cap truncated it

The `-f` format flag governs only the report artefact; siblings are always JSON. Cancelled runs are skipped, matching the existing `save_report` behaviour. The README already documents this feature (shipped ahead of the code in cb2170a).

## Design notes

- **No credential leakage.** `ModelDescriptor` records `provider`/`model_name` only — API keys and endpoints are deliberately excluded so a manifest is safe to commit to git or attach to a ticket. `config_hash` fingerprints the input contract without exposing it.
- **Path redaction.** Filesystem paths in the plan/findings siblings are rewritten relative to cwd (`./…`) or `$HOME` (`~/…`) so they don't leak local layout. In-memory objects are not mutated — the auto-saved archive still gets verbatim values.
- **Reference tracking.** `execute_tool` takes an optional `loaded_refs` set that the analyze and quick loops thread through, so the manifest records the cards that actually shaped the output (`references_loaded`).
- **Run completeness.** `run_summary` carries `status` (`completed` / `partial`), `subsystems_planned` / `subsystems_analyzed` (null for `/quick`), and `llm_calls` / `tool_calls`. `status` is `partial` when a `--max-llm-calls` / `--max-tool-calls` cap stopped `/analyze` before every planned subsystem was reached — without this, a truncated `findings.json` was indistinguishable from a complete one.

## Testing

- New `tests/test_persistence.py` — 21 tests covering redaction, config-hash stability/sensitivity, sibling emission per mode, format-flag independence, manifest round-trip, and the completed-vs-partial run summary logic.
- Full suite green: **325 passed**.

## Commits

1. `feat: persist structured intermediates alongside exported reports (#122)`
2. `feat: record run completeness in the run manifest (#122)`

## Follow-up (not in this PR)

Validating the intermediates surfaced a pre-existing rendering bug — a comma-separated-string `MITRE_ATTACK` is dropped by the markdown table and SARIF export while `findings.json` preserves it. Filed separately as #134; `report_utils.py` / `report.py` are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
