### PR TITLE
docs: fix documentation drift found in doc review

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,6 @@ GOOGLE_API_KEY=your_google_api_key_here
 MISTRAL_API_KEY=your_mistral_api_key_here
 GROQ_API_KEY=your_groq_api_key_here
 DEEPSEEK_API_KEY=your_deepseek_api_key_here
-OLLAMA_ENDPOINT=http://localhost:11434
 LM_STUDIO_ENDPOINT=http://localhost:1234
 
 # Optional. Host for the Streamlit diagram editor (embedded draw.io). Defaults

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ Three phases, all driven from `cli.py:analyze` (the subcommand) or `_handle_anal
 2. **Per-subsystem analysis** (`agent/loop.py:_analyze_subsystem`) — for each subsystem, a tool-using agent loop. The model reads files, greps, lists directories, and loads OWASP reference cards on demand, then emits a JSON finding. Token budget is shared across subsystems (remaining-budget arithmetic in `run_analysis`).
 3. **Synthesis** (`agent/loop.py:_synthesize`) — one LLM call. Reviews all per-subsystem findings and surfaces cross-cutting threats.
 
-Reports auto-save to `~/.stride-gpt/reports/<target>_<timestamp>.json`. The `/reports` slash command lists and re-renders saved reports.
+Reports auto-save under `~/.stride-gpt/reports/`, split by kind: `/analyze` runs land in `reports/analyze/<target>_<timestamp>.json` and `/quick` runs in `reports/quick/<name>_<timestamp>.json` (see `config.py:analyze_reports_dir` / `quick_reports_dir`). The `/reports` slash command lists and re-renders saved reports (`--quick` / `--all` switch which kind it shows).
 
 ## Progressive disclosure pattern
 

--- a/README.md
+++ b/README.md
@@ -386,9 +386,16 @@ Inside the REPL, type `/help` to see available commands and flags.
 |------|-------------|
 | `-o`, `--output` | Save report to a file |
 | `-f`, `--format` | Output format: `markdown` (default), `json`, `sarif`, `html` |
+| `-i`, `--input` | Read the app description from a file (`quick` only) |
 | `-y`, `--yes` | Auto-approve the analysis plan (`analyze` only) |
 | `--worker-model` | Default-tier model handling the bulk of calls (e.g. `anthropic/claude-sonnet-4-6`). Uses saved config if omitted. |
 | `--architect-model` | Stronger model for planning/synthesis (e.g. `openai/gpt-5.4`). Uses saved config if omitted. |
+| `--no-architect` | Skip the architect tier for this run; the worker handles every call. |
+| `--app-type` | Override the planner's detected app type (`analyze` only): `auto` (default), `web`, `genai`, `agentic`. |
+| `--max-llm-calls` | Cap total LLM calls across both tiers (`analyze` only; `0` = unlimited). |
+| `--max-tool-calls` | Cap total tool executions (`analyze` only; `0` = unlimited). |
+
+Each tier also accepts `--worker-api-key` / `--worker-api-base` / `--worker-max-tokens` (and the `--architect-*` equivalents). Run `stride-gpt analyze --help` or `stride-gpt quick --help` for the complete list.
 
 **Structured intermediates** — when `-o <path>` is used, three JSON siblings are written alongside the report so the run can be audited or consumed by downstream tools:
 

--- a/docs/operationalization-guide.md
+++ b/docs/operationalization-guide.md
@@ -318,7 +318,7 @@ The file should define your security context as a text string including:
 
 ### Step 3: Modify the Threat Model Prompt
 
-Open `apps/web/threat_model.py` and find the `create_threat_model_prompt` function.
+Open `stride_gpt/core/prompts/builder.py` and find the `create_threat_model_prompt` function. (The web UI re-exports it from `apps/web/threat_model.py`, but the prompt body now lives in the shared core builder — so this one change affects both the Streamlit UI and any code path that builds the single-shot prompt.)
 
 **Key changes needed:**
 1. Import your organizational context: `from apps.web.org_context import get_org_context`

--- a/stride_gpt/cli.py
+++ b/stride_gpt/cli.py
@@ -688,7 +688,7 @@ def _resolve_provider(model: str) -> tuple[str, str]:
 @app.command()
 def analyze(
     path: Annotated[Path, typer.Argument(help="Path to the codebase to analyze.")] = Path("."),
-    worker_model: Annotated[Optional[str], typer.Option(help="Worker model — default tier, handles the bulk of calls (e.g. anthropic/claude-sonnet-4-5). A fast, low-cost model usually pays off here. Uses saved config if omitted.")] = None,
+    worker_model: Annotated[Optional[str], typer.Option(help="Worker model — default tier, handles the bulk of calls (e.g. anthropic/claude-sonnet-4-6). A fast, low-cost model usually pays off here. Uses saved config if omitted.")] = None,
     worker_api_key: Annotated[Optional[str], typer.Option(envvar="STRIDE_GPT_API_KEY", help="Worker API key.")] = None,
     worker_api_base: Annotated[Optional[str], typer.Option(help="Worker API base URL (LM Studio).")] = None,
     worker_max_tokens: Annotated[Optional[int], typer.Option(help="Worker per-call output token cap.")] = None,

--- a/stride_gpt/core/schemas.py
+++ b/stride_gpt/core/schemas.py
@@ -12,7 +12,7 @@ class LLMConfig(BaseModel):
     """Configuration for an LLM call. Constructed by UI layer from session state."""
 
     provider: str  # "OpenAI API", "Anthropic API", "Google AI API", etc.
-    model_name: str  # bare name e.g. "gpt-5.2", "claude-sonnet-4-5-20250929"
+    model_name: str  # bare name e.g. "gpt-5.4", "claude-sonnet-4-6"
     api_key: str  # BYOK key, passed per-call
     api_base: str | None = None  # For LM Studio custom endpoints
     timeout: int | None = None  # Request timeout in seconds


### PR DESCRIPTION
## Summary

Fixes six documentation-drift items surfaced by a `/doc-review` audit. Docs-and-help-text only — no behavioural code changed.

| File | Fix |
|------|-----|
| `.env.example` | Removed the dead `OLLAMA_ENDPOINT` line — Ollama isn't a supported provider and nothing reads the var (local hosting goes through LM Studio). |
| `stride_gpt/cli.py` | `analyze --worker-model` help example `claude-sonnet-4-5` → `claude-sonnet-4-6` (the 4-5 model isn't in the catalogue). |
| `AGENTS.md` | Report storage is no longer a flat `reports/` dir; documents the `reports/analyze/` and `reports/quick/` split. |
| `docs/operationalization-guide.md` | Step 3 pointed readers at `create_threat_model_prompt` in `apps/web/threat_model.py`, but the body now lives in `stride_gpt/core/prompts/builder.py` (web only re-exports it). |
| `README.md` | Flags table was missing `--no-architect`, `--app-type`, `--max-llm-calls`, `--max-tool-calls`, and `-i/--input`. |
| `stride_gpt/core/schemas.py` | Refreshed stale model-name examples (`gpt-5.2`, `claude-sonnet-4-5-...`) in the `LLMConfig` comment. |

## Verification

Each item was checked against ground truth in the code before editing:
- No `ollama` references anywhere in `stride_gpt/`, `apps/`, `scripts/`; only `LM_STUDIO_ENDPOINT` is consumed.
- `claude-sonnet-4-6` is the catalogued Anthropic model in `stride_gpt/models.py`; no `4-5` entry exists.
- `config.py:analyze_reports_dir` / `quick_reports_dir` confirm the kind-split report layout.
- `create_threat_model_prompt` is defined only in `stride_gpt/core/prompts/builder.py:246`.
- New README flag rows match the actual Typer options in `cli.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)