### PR TITLE
test: cover high-risk untested seams (drawio parser, key fallback, JSON error paths)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ dist/
 
 # Doc-review report (local only)
 doc-review.html
+
+# Test-optimizer report (local only)
+test-optimization.html

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -108,6 +108,55 @@ class TestGetApiKey:
         assert get_api_key(cfg, tier="architect") == ""
 
 
+class TestGetApiKeyWorkerFallback:
+    """The worker tier's last-resort scan of common env vars, used when the
+    provider's own env var is unset (legacy behaviour)."""
+
+    @staticmethod
+    def _clear_all(monkeypatch):
+        for var in (
+            "ANTHROPIC_API_KEY",
+            "STRIDE_GPT_API_KEY",
+            "OPENAI_API_KEY",
+            "GOOGLE_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_falls_back_to_generic_env_var_when_provider_var_unset(
+        self, single_tier_config, monkeypatch
+    ):
+        # Anthropic's own ANTHROPIC_API_KEY is unset, so the worker falls back
+        # to the generic STRIDE_GPT_API_KEY.
+        self._clear_all(monkeypatch)
+        monkeypatch.setenv("STRIDE_GPT_API_KEY", "generic-key")
+        assert get_api_key(single_tier_config, tier="worker") == "generic-key"
+
+    def test_stride_gpt_key_takes_precedence_in_fallback_chain(
+        self, single_tier_config, monkeypatch
+    ):
+        # STRIDE_GPT_API_KEY is checked before the provider-branded vars.
+        self._clear_all(monkeypatch)
+        monkeypatch.setenv("STRIDE_GPT_API_KEY", "first")
+        monkeypatch.setenv("OPENAI_API_KEY", "second")
+        assert get_api_key(single_tier_config, tier="worker") == "first"
+
+    def test_provider_var_wins_over_generic_fallback(
+        self, single_tier_config, monkeypatch
+    ):
+        # When the provider's own env var IS set, the generic fallback is never
+        # consulted — no risk of the wrong key winning.
+        self._clear_all(monkeypatch)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "provider-key")
+        monkeypatch.setenv("STRIDE_GPT_API_KEY", "generic-key")
+        assert get_api_key(single_tier_config, tier="worker") == "provider-key"
+
+    def test_returns_empty_string_when_no_key_available(
+        self, single_tier_config, monkeypatch
+    ):
+        self._clear_all(monkeypatch)
+        assert get_api_key(single_tier_config, tier="worker") == ""
+
+
 class TestLoadConfig:
     def test_returns_none_when_no_worker_model(self, tmp_path, monkeypatch):
         cfg_dir = tmp_path / ".stride-gpt"

--- a/tests/test_drawio_parser.py
+++ b/tests/test_drawio_parser.py
@@ -1,0 +1,142 @@
+"""Tests for stride_gpt.core.drawio_parser.
+
+The parser turns untrusted, user-drawn draw.io XML into the authoritative
+component/data-flow model injected into threat-modelling prompts
+(apps/web/main.py). Two things must hold: it extracts the diagram structure
+correctly, and it degrades safely (never expands entities, never raises) on
+malformed or malicious input.
+"""
+
+from __future__ import annotations
+
+from stride_gpt.core.drawio_parser import drawio_to_prompt_section, parse_drawio_xml
+
+# A flat diagram: three vertices, two edges, no groups. Mirrors the module's
+# own __main__ smoke sample (which pytest never runs).
+FLAT_XML = """<mxGraphModel><root>
+  <mxCell id="0"/><mxCell id="1" parent="0"/>
+  <mxCell id="2" value="User" vertex="1" parent="1" style="ellipse;"><mxGeometry/></mxCell>
+  <mxCell id="3" value="Web App" vertex="1" parent="1" style="rounded=1;"><mxGeometry/></mxCell>
+  <mxCell id="4" value="Database" vertex="1" parent="1" style="shape=cylinder;"><mxGeometry/></mxCell>
+  <mxCell id="5" value="HTTPS" edge="1" source="2" target="3" parent="1"><mxGeometry/></mxCell>
+  <mxCell id="6" value="SQL" edge="1" source="3" target="4" parent="1"><mxGeometry/></mxCell>
+</root></mxGraphModel>"""
+
+# A grouped diagram: a swimlane "DMZ" containing two vertices with an edge
+# between them.
+GROUPED_XML = """<mxGraphModel><root>
+  <mxCell id="0"/><mxCell id="1" parent="0"/>
+  <mxCell id="z" value="DMZ" vertex="1" parent="1" style="swimlane;"><mxGeometry/></mxCell>
+  <mxCell id="a" value="Web" vertex="1" parent="z" style="rounded=1;"><mxGeometry/></mxCell>
+  <mxCell id="b" value="DB" vertex="1" parent="z" style="shape=cylinder;"><mxGeometry/></mxCell>
+  <mxCell id="e" value="query" edge="1" source="a" target="b" parent="1"><mxGeometry/></mxCell>
+</root></mxGraphModel>"""
+
+
+class TestParseFlatDiagram:
+    def test_extracts_all_labeled_vertices_as_components(self):
+        result = parse_drawio_xml(FLAT_XML)
+        labels = {c["label"] for c in result["components"]}
+        assert labels == {"User", "Web App", "Database"}
+
+    def test_root_and_layer_cells_are_not_components(self):
+        # Cells "0" and "1" are the model root and default layer, never components.
+        result = parse_drawio_xml(FLAT_XML)
+        assert all(c["id"] not in ("0", "1") for c in result["components"])
+
+    def test_flat_components_have_no_group(self):
+        result = parse_drawio_xml(FLAT_XML)
+        assert all(c["group"] is None for c in result["components"])
+
+    def test_edges_resolve_endpoint_ids_to_labels(self):
+        result = parse_drawio_xml(FLAT_XML)
+        flows = {(c["from"], c["to"]): c["label"] for c in result["connections"]}
+        assert flows == {("User", "Web App"): "HTTPS", ("Web App", "Database"): "SQL"}
+
+    def test_flat_diagram_has_no_trust_boundaries(self):
+        result = parse_drawio_xml(FLAT_XML)
+        assert result["trust_boundaries"] == []
+
+
+class TestParseGroupedDiagram:
+    def test_grouped_vertices_carry_their_group_label(self):
+        result = parse_drawio_xml(GROUPED_XML)
+        by_label = {c["label"]: c for c in result["components"]}
+        assert by_label["Web"]["group"] == "DMZ"
+        assert by_label["DB"]["group"] == "DMZ"
+
+    def test_swimlane_becomes_a_trust_boundary_with_its_members(self):
+        result = parse_drawio_xml(GROUPED_XML)
+        assert len(result["trust_boundaries"]) == 1
+        boundary = result["trust_boundaries"][0]
+        assert boundary["name"] == "DMZ"
+        assert set(boundary["members"]) == {"Web", "DB"}
+
+    def test_edge_inside_group_still_resolves(self):
+        result = parse_drawio_xml(GROUPED_XML)
+        assert {"label": "query", "from": "Web", "to": "DB"} in result["connections"]
+
+
+class TestWrapperHandling:
+    def test_mxfile_diagram_wrapper_is_unwrapped(self):
+        wrapped = f"<mxfile><diagram>{FLAT_XML}</diagram></mxfile>"
+        result = parse_drawio_xml(wrapped)
+        assert len(result["components"]) == 3
+        assert len(result["connections"]) == 2
+
+    def test_well_formed_xml_without_graph_model_is_empty(self):
+        result = parse_drawio_xml("<mxfile><diagram></diagram></mxfile>")
+        assert result == {"components": [], "connections": [], "trust_boundaries": []}
+
+
+class TestMalformedAndMaliciousInput:
+    def test_empty_string_returns_empty_structures(self):
+        assert parse_drawio_xml("") == {
+            "components": [],
+            "connections": [],
+            "trust_boundaries": [],
+        }
+
+    def test_truncated_xml_returns_empty_structures(self):
+        assert parse_drawio_xml("<bad xml") == {
+            "components": [],
+            "connections": [],
+            "trust_boundaries": [],
+        }
+
+    def test_entity_expansion_is_blocked_not_expanded(self):
+        # A billion-laughs / internal-entity payload: defusedxml must refuse the
+        # DTD rather than expand it, and the parser must swallow the exception
+        # and return empty structures — never an expanded/oversized document.
+        billion_laughs = """<?xml version="1.0"?>
+        <!DOCTYPE lolz [
+          <!ENTITY lol "lol">
+          <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;">
+        ]>
+        <mxGraphModel><root>
+          <mxCell id="2" value="&lol1;" vertex="1" parent="1"/>
+        </root></mxGraphModel>"""
+        result = parse_drawio_xml(billion_laughs)
+        assert result == {
+            "components": [],
+            "connections": [],
+            "trust_boundaries": [],
+        }
+
+
+class TestDrawioToPromptSection:
+    def test_empty_input_yields_empty_string(self):
+        # Callers rely on truthiness to decide whether to inject the section.
+        assert drawio_to_prompt_section("") == ""
+        assert drawio_to_prompt_section("<bad xml") == ""
+
+    def test_diagram_with_no_components_or_connections_yields_empty_string(self):
+        assert drawio_to_prompt_section("<mxGraphModel><root/></mxGraphModel>") == ""
+
+    def test_populated_section_lists_components_flows_and_boundaries(self):
+        section = drawio_to_prompt_section(GROUPED_XML)
+        assert "Components:" in section
+        assert "Data Flows:" in section
+        assert "Web -> DB" in section
+        assert "Trust Boundaries / Security Zones:" in section
+        assert "DMZ" in section

--- a/tests/test_llm_response.py
+++ b/tests/test_llm_response.py
@@ -1,0 +1,66 @@
+"""Tests for the pure response-parsing helpers in stride_gpt.core.llm.
+
+extract_deepseek_reasoning and process_groq_response are deterministic string
+transforms with no external deps — they split reasoning from the answer and
+route a Groq/DeepSeek response to JSON, Mermaid, or raw text.
+"""
+
+from __future__ import annotations
+
+from stride_gpt.core.llm import extract_deepseek_reasoning, process_groq_response
+
+
+class TestExtractDeepseekReasoning:
+    def test_splits_reasoning_from_answer(self):
+        text = "<think>weighing options</think>Final answer here."
+        reasoning, answer = extract_deepseek_reasoning(text)
+        assert reasoning == "weighing options"
+        assert answer == "Final answer here."
+
+    def test_no_tags_returns_none_reasoning_and_original_text(self):
+        reasoning, answer = extract_deepseek_reasoning("just an answer")
+        assert reasoning is None
+        assert answer == "just an answer"
+
+    def test_multiline_reasoning_across_tags(self):
+        text = "<think>line one\nline two</think>\n{\"ok\": true}"
+        reasoning, answer = extract_deepseek_reasoning(text)
+        assert reasoning == "line one\nline two"
+        assert answer == '{"ok": true}'
+
+    def test_reasoning_is_stripped(self):
+        reasoning, _ = extract_deepseek_reasoning("<think>  padded  </think>answer")
+        assert reasoning == "padded"
+
+
+class TestProcessGroqResponse:
+    def test_valid_json_is_parsed_to_dict(self):
+        reasoning, output = process_groq_response('{"a": 1}', "some-model", expect_json=True)
+        assert reasoning is None
+        assert output == {"a": 1}
+
+    def test_invalid_json_falls_back_to_raw_text(self):
+        reasoning, output = process_groq_response("not json", "some-model", expect_json=True)
+        assert reasoning is None
+        assert output == "not json"
+
+    def test_deepseek_model_extracts_reasoning_before_json(self):
+        text = '<think>reasoning</think>{"a": 1}'
+        reasoning, output = process_groq_response(
+            text, "deepseek-r1-distill-llama-70b", expect_json=True
+        )
+        assert reasoning == "reasoning"
+        assert output == {"a": 1}
+
+    def test_non_json_mermaid_response_is_extracted(self):
+        text = "```mermaid\ngraph TD\n  a-->b\n```"
+        reasoning, output = process_groq_response(text, "some-model", expect_json=False)
+        assert reasoning is None
+        assert output.startswith("graph")
+
+    def test_non_json_plain_text_passthrough(self):
+        reasoning, output = process_groq_response(
+            "just prose, no graph", "some-model", expect_json=False
+        )
+        assert reasoning is None
+        assert output == "just prose, no graph"

--- a/tests/test_threat_model.py
+++ b/tests/test_threat_model.py
@@ -1,0 +1,85 @@
+"""Tests for stride_gpt.core.threat_model parsing helpers.
+
+Focus on the resilience path: local models frequently emit prose or
+fence-wrapped JSON instead of a clean object, so the parser must clean common
+noise and, on genuine failure, return a well-formed ThreatModelOutput carrying
+a structured error rather than raising into the caller.
+"""
+
+from __future__ import annotations
+
+from stride_gpt.core.threat_model import (
+    _clean_json_content,
+    _parse_threat_model_response,
+)
+
+
+class TestParseThreatModelResponse:
+    def test_parses_valid_json(self):
+        content = (
+            '{"threat_model": [{"Threat Type": "Spoofing", "Scenario": "s", '
+            '"Potential Impact": "i"}], "improvement_suggestions": ["fix it"]}'
+        )
+        parsed = _parse_threat_model_response(content)
+        assert parsed.threat_model[0]["Threat Type"] == "Spoofing"
+        assert parsed.improvement_suggestions == ["fix it"]
+
+    def test_malformed_json_yields_structured_error(self):
+        parsed = _parse_threat_model_response("the model rambled instead {{{")
+        assert len(parsed.threat_model) == 1
+        assert parsed.threat_model[0]["Threat Type"] == "Error"
+        assert "Failed to parse" in parsed.threat_model[0]["Scenario"]
+
+    def test_error_fallback_includes_raw_snippet(self):
+        parsed = _parse_threat_model_response("not json <b>hi</b>")
+        joined = " ".join(parsed.improvement_suggestions)
+        assert "JSON parse error" in joined
+        assert "not json" in joined
+
+    def test_error_snippet_escapes_pipes_for_markdown_table(self):
+        # The snippet lands in a markdown table cell; unescaped pipes would
+        # break the table layout.
+        parsed = _parse_threat_model_response("a | b | c not json {{{")
+        joined = " ".join(parsed.improvement_suggestions)
+        assert "\\|" in joined
+
+    def test_empty_response_reports_empty_placeholder(self):
+        parsed = _parse_threat_model_response("")
+        joined = " ".join(parsed.improvement_suggestions)
+        assert "(empty response)" in joined
+
+    def test_long_snippet_is_truncated(self):
+        parsed = _parse_threat_model_response("x" * 1000 + " not json {{{")
+        joined = " ".join(parsed.improvement_suggestions)
+        assert "..." in joined
+
+    def test_missing_keys_default_to_empty_lists(self):
+        parsed = _parse_threat_model_response('{"threat_model": []}')
+        assert parsed.threat_model == []
+        assert parsed.improvement_suggestions == []
+
+
+class TestCleanJsonContent:
+    def test_strips_json_fence(self):
+        assert _clean_json_content('```json\n{"a": 1}\n```') == '{"a": 1}'
+
+    def test_strips_bare_fence(self):
+        assert _clean_json_content('```\n{"a": 1}\n```') == '{"a": 1}'
+
+    def test_removes_line_comments(self):
+        cleaned = _clean_json_content('{"a": 1} // a comment\n')
+        assert "//" not in cleaned
+
+    def test_repairs_trailing_comma_before_bracket(self):
+        cleaned = _clean_json_content('{"x": [1,\n]}')
+        assert ",\n]" not in cleaned
+
+    def test_fenced_json_with_comment_becomes_parseable(self):
+        import json
+
+        raw = '```json\n{"threat_model": [], // note\n"improvement_suggestions": []}\n```'
+        cleaned = _clean_json_content(raw)
+        assert json.loads(cleaned) == {
+            "threat_model": [],
+            "improvement_suggestions": [],
+        }


### PR DESCRIPTION
## Summary

Implements the **high-confidence** findings from the test-optimizer audit. These are the seams carrying real risk that had zero pytest coverage — several were only "tested" by `__main__` blocks that pytest never runs.

**+41 net tests, full suite 436 passing.** No source changes: `defusedxml` was already a declared dependency.

## What's covered

| Area | Why it matters | New tests |
|------|----------------|-----------|
| `core/drawio_parser.py` | Untrusted, user-drawn XML fed straight into threat-modelling prompts (`apps/web/main.py`). Added in #132/#138 with 0% coverage. | Structure extraction (components, edges, swimlane groups, trust boundaries, `mxfile` wrapper); safe degradation on empty/truncated XML; **verifies `defusedxml` blocks entity-expansion** (billion-laughs) rather than expanding it. |
| `config.get_api_key` | Credential resolution — wrong precedence means auth failures or the wrong key winning. | Worker last-resort env-var fallback chain: `STRIDE_GPT_API_KEY` precedence, provider-var-wins, empty-when-absent. |
| `core/threat_model.py` | The resilience path local models hit when they emit prose instead of JSON. | JSON-parse failure returns a structured `Error` `ThreatModelOutput` with an escaped/truncated snippet; `_clean_json_content` fence/comment/trailing-comma repair. |
| `core/llm.py` | Deterministic response routing with live callers. | `extract_deepseek_reasoning` `<think>`-tag splitting; `process_groq_response` JSON / Mermaid / passthrough branches. |

Also gitignores the local `test-optimization.html` report.

## Out of scope

Medium-confidence findings (LM Studio helpers, `_call_litellm` mocked-response paths, `clean_mermaid_syntax` edge cases) and the reconsider items are left for a follow-up.

## Test plan
- [x] `pytest` — 436 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)