### PR TITLE
fix: recover comma-separated-string MITRE_ATTACK across renderers (#134)

### DIFF
--- a/stride_gpt/agent/html_report.py
+++ b/stride_gpt/agent/html_report.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from stride_gpt.core.report_utils import mitre_url
+from stride_gpt.core.report_utils import mitre_url, normalize_mitre_techniques
 from stride_gpt.core.schemas import AnalysisReport
 
 # STRIDE category → Tailwind badge classes. Six categories carry distinct
@@ -372,26 +372,19 @@ def _render_threat_card(threat: dict[str, Any], *, cross_cutting: bool) -> str:
 def _render_mitre_pills(value: Any) -> list[str]:
     """Render MITRE ATT&CK techniques as linked pills.
 
-    Accepts the canonical list-of-objects shape and the simpler list-of-
-    strings fallback. Each pill links to attack.mitre.org / atlas.mitre.org
-    when the ID matches a known prefix; otherwise it renders as plain text.
-    Returns an empty list if the field is absent / empty / malformed —
-    threat cards without MITRE mappings render exactly as before.
+    Delegates shape handling to
+    :func:`stride_gpt.core.report_utils.normalize_mitre_techniques`, so the
+    canonical list-of-objects, the list-of-strings fallback, and the comma-
+    separated-string shape all render. Each pill links to attack.mitre.org /
+    atlas.mitre.org when the ID matches a known prefix; otherwise it renders
+    as plain text. Returns an empty list if the field is absent / empty /
+    malformed — threat cards without MITRE mappings render exactly as before.
     """
-    if not isinstance(value, list) or not value:
+    techniques = normalize_mitre_techniques(value)
+    if not techniques:
         return []
     pills: list[str] = []
-    for entry in value:
-        if isinstance(entry, dict):
-            tid = str(entry.get("id") or "").strip()
-            name = str(entry.get("name") or "").strip()
-        elif isinstance(entry, str):
-            tid = entry.strip()
-            name = ""
-        else:
-            continue
-        if not tid:
-            continue
+    for tid, name in techniques:
         label = f"{tid} {name}" if name else tid
         url = mitre_url(tid)
         if url:

--- a/stride_gpt/agent/report.py
+++ b/stride_gpt/agent/report.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from stride_gpt.core.report_utils import (
     detect_extra_columns,
+    normalize_mitre_techniques,
     threat_table_header,
     threat_table_row,
 )
@@ -302,23 +303,14 @@ def render_sarif(report: AnalysisReport) -> dict[str, Any]:
 def _sarif_mitre_ids(value: Any) -> list[str]:
     """Extract a plain list of MITRE technique IDs for SARIF properties.
 
-    Accepts the canonical list-of-objects shape and the list-of-strings
-    fallback. Returns an empty list for missing / malformed input so callers
-    can use truthiness to decide whether to attach the property.
+    Delegates shape handling to
+    :func:`stride_gpt.core.report_utils.normalize_mitre_techniques`, so the
+    canonical list-of-objects, the list-of-strings fallback, and the comma-
+    separated-string shape all contribute IDs. Returns an empty list for
+    missing / malformed input so callers can use truthiness to decide whether
+    to attach the property.
     """
-    if not isinstance(value, list):
-        return []
-    ids: list[str] = []
-    for entry in value:
-        if isinstance(entry, dict):
-            tid = str(entry.get("id") or "").strip()
-        elif isinstance(entry, str):
-            tid = entry.strip()
-        else:
-            continue
-        if tid:
-            ids.append(tid)
-    return ids
+    return [tid for tid, _name in normalize_mitre_techniques(value)]
 
 
 # ---------------------------------------------------------------------------

--- a/stride_gpt/core/report_utils.py
+++ b/stride_gpt/core/report_utils.py
@@ -42,7 +42,12 @@ def detect_extra_columns(
         show_llm=any(t.get("OWASP_LLM") for t in threats),
         show_asi=any(t.get("OWASP_ASI") for t in threats),
         show_insider=any(t.get("INSIDER_CATEGORY") for t in threats),
-        show_mitre=any(t.get("MITRE_ATTACK") for t in threats),
+        # Use the same normaliser as the cell renderer so the column is shown
+        # only when at least one threat yields a technique the cell can render.
+        # A truthiness check here would resurface the present-but-blank column
+        # bug for values that are truthy but normalize to nothing (e.g. a bare
+        # int, or the string shape before it was handled).
+        show_mitre=any(normalize_mitre_techniques(t.get("MITRE_ATTACK")) for t in threats),
     )
 
 
@@ -121,29 +126,79 @@ def threat_table_row(
     return "| " + " | ".join(cells) + " |"
 
 
-def format_mitre_cell(value: Any) -> str:
-    """Render a ``MITRE_ATTACK`` list as a compact markdown cell.
+def is_mitre_technique_id(value: str) -> bool:
+    """Return ``True`` if ``value`` looks like a MITRE technique ID.
 
-    Accepts the canonical list-of-objects shape
-    (``[{"id": "T1190", "name": "..."}]``) and the simpler list-of-strings
-    fallback (``["T1190", "T1078"]``). Pipes and newlines inside names are
-    sanitized so the table stays valid even if the model emits unusual
-    characters. Empty / missing / non-list input renders as an empty cell.
+    Recognizes the same shapes :func:`mitre_url` links: enterprise ATT&CK
+    ``T####`` (with an optional ``.###`` sub-technique suffix) and ATLAS
+    ``AML.*``. Used to tell real technique IDs apart from prose when a model
+    emits ``MITRE_ATTACK`` as a bare or comma-separated string, so junk like
+    ``"see the notes"`` is dropped rather than rendered as a technique.
     """
-    if not isinstance(value, list) or not value:
-        return ""
-    parts: list[str] = []
-    for entry in value:
+    tid = value.strip()
+    if tid.startswith("AML.") and len(tid) > len("AML."):
+        return True
+    return tid.startswith("T") and len(tid) > 1 and tid[1].isdigit()
+
+
+def normalize_mitre_techniques(value: Any) -> list[tuple[str, str]]:
+    """Normalize a ``MITRE_ATTACK`` field into ``(id, name)`` pairs.
+
+    Accepts every shape models emit for this field:
+
+    - the canonical list-of-objects (``[{"id": "T1190", "name": "..."}]``),
+    - the list-of-strings fallback (``["T1190", "T1078"]``), and
+    - the comma-separated-string shape that smaller/cheaper worker models
+      often emit instead (``"T1190, T1059, AML.T0053"``).
+
+    Names are only carried by the list-of-objects shape; the other shapes
+    yield an empty name. String values (whether the whole field or a single
+    list entry) are split on commas so the string shape is recovered rather
+    than dropped. Tokens parsed out of a string are kept only when they look
+    like MITRE IDs (see :func:`is_mitre_technique_id`), so a prose value never
+    turns into a fake technique; ``id``s from the structured object shape are
+    trusted as-is. Empty / missing / unrecognized input yields ``[]``.
+
+    This is the single source of truth for interpreting ``MITRE_ATTACK`` so
+    the markdown, HTML, and SARIF renderers can never disagree on which
+    shapes count as populated.
+    """
+    if not value:
+        return []
+    if isinstance(value, str):
+        entries: list[Any] = [value]
+    elif isinstance(value, list):
+        entries = value
+    else:
+        return []
+    techniques: list[tuple[str, str]] = []
+    for entry in entries:
         if isinstance(entry, dict):
             tid = str(entry.get("id") or "").strip()
             name = str(entry.get("name") or "").strip()
-            if not tid:
-                continue
-            parts.append(f"{tid} ({name})" if name else tid)
-        elif isinstance(entry, str):
-            tid = entry.strip()
             if tid:
-                parts.append(tid)
+                techniques.append((tid, name))
+        elif isinstance(entry, str):
+            for part in entry.split(","):
+                tid = part.strip()
+                if tid and is_mitre_technique_id(tid):
+                    techniques.append((tid, ""))
+    return techniques
+
+
+def format_mitre_cell(value: Any) -> str:
+    """Render a ``MITRE_ATTACK`` value as a compact markdown cell.
+
+    Delegates shape handling to :func:`normalize_mitre_techniques`, so the
+    canonical list-of-objects, the list-of-strings fallback, and the comma-
+    separated-string shape all render. Pipes and newlines inside names are
+    sanitized so the table stays valid even if the model emits unusual
+    characters. Empty / missing / unrecognized input renders as an empty cell.
+    """
+    techniques = normalize_mitre_techniques(value)
+    if not techniques:
+        return ""
+    parts = [f"{tid} ({name})" if name else tid for tid, name in techniques]
     return _escape_md_cell(", ".join(parts))
 
 
@@ -157,12 +212,12 @@ def mitre_url(technique_id: str) -> str:
     to plain text in that case rather than producing a broken link.
     """
     tid = technique_id.strip()
+    if not is_mitre_technique_id(tid):
+        return ""
     if tid.startswith("AML."):
         return f"https://atlas.mitre.org/techniques/{tid}/"
-    if tid.startswith("T") and len(tid) > 1 and tid[1].isdigit():
-        # Enterprise sub-techniques: T1078.004 → /techniques/T1078/004/
-        if "." in tid:
-            parent, _, sub = tid.partition(".")
-            return f"https://attack.mitre.org/techniques/{parent}/{sub}/"
-        return f"https://attack.mitre.org/techniques/{tid}/"
-    return ""
+    # Enterprise sub-techniques: T1078.004 → /techniques/T1078/004/
+    if "." in tid:
+        parent, _, sub = tid.partition(".")
+        return f"https://attack.mitre.org/techniques/{parent}/{sub}/"
+    return f"https://attack.mitre.org/techniques/{tid}/"

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -494,6 +494,26 @@ class TestMitreAttackColumn:
         assert "MITRE ATT&CK" in md
         assert "T1565 (Data Manipulation)" in md
 
+    def test_comma_separated_string_shape_renders_everywhere(self, sample_plan):
+        """#134: smaller worker models emit MITRE_ATTACK as one comma-separated
+        string. The column previously showed but every cell (and the SARIF
+        property) came out blank. Assert the string shape now flows through
+        markdown, SARIF, and HTML alike."""
+        report = self._report_with_mitre(sample_plan, "T1110, T1078, AML.T0051")
+
+        md = render_markdown(report)
+        assert "MITRE ATT&CK" in md
+        assert "| T1110, T1078, AML.T0051 |" in md
+
+        sarif = render_sarif(report)
+        result = sarif["runs"][0]["results"][0]
+        assert result["properties"]["mitre_attack"] == ["T1110", "T1078", "AML.T0051"]
+
+        html = render_html(report)
+        # Each ID becomes a linked pill; AML routes to ATLAS, T-codes to ATT&CK.
+        assert "https://attack.mitre.org/techniques/T1110/" in html
+        assert "https://atlas.mitre.org/techniques/AML.T0051/" in html
+
 
 # ---------------------------------------------------------------------------
 # Report persistence — separate folders for /analyze and /quick

--- a/tests/test_report_sarif.py
+++ b/tests/test_report_sarif.py
@@ -77,7 +77,7 @@ class TestSarifText:
 
 
 # ---------------------------------------------------------------------------
-# _sarif_mitre_ids — list-of-objects + list-of-strings shapes
+# _sarif_mitre_ids — list-of-objects, list-of-strings, comma-string shapes
 # ---------------------------------------------------------------------------
 
 
@@ -89,9 +89,14 @@ class TestSarifMitreIds:
     def test_list_of_strings_fallback(self):
         assert _sarif_mitre_ids(["T1059", "T1078"]) == ["T1059", "T1078"]
 
-    def test_non_list_returns_empty(self):
-        assert _sarif_mitre_ids("T1059") == []
+    def test_comma_separated_string_recovered(self):
+        """#134: string-shaped MITRE IDs must reach SARIF, not get dropped."""
+        assert _sarif_mitre_ids("T1190, T1059, AML.T0053") == ["T1190", "T1059", "AML.T0053"]
+
+    def test_empty_and_prose_return_empty(self):
         assert _sarif_mitre_ids(None) == []
+        assert _sarif_mitre_ids("") == []
+        assert _sarif_mitre_ids("no techniques identified") == []
 
     def test_skips_malformed_and_empty_entries(self):
         value = [{"id": "T1"}, {"id": ""}, 42, {"no_id": "x"}, "  ", "T2"]

--- a/tests/test_report_utils.py
+++ b/tests/test_report_utils.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from stride_gpt.core.report_utils import (
     detect_extra_columns,
     format_mitre_cell,
+    is_mitre_technique_id,
     mitre_url,
+    normalize_mitre_techniques,
     threat_table_header,
     threat_table_row,
 )
@@ -43,6 +45,17 @@ class TestDetectExtraColumns:
             {"Threat Type": "C", "MITRE_ATTACK": [{"id": "T1078", "name": "Valid Accounts"}]},
         ]
         assert detect_extra_columns(threats) == (True, False, False, True)
+
+    def test_mitre_comma_separated_string_shows_column(self):
+        """#134: a comma-separated MITRE string must surface the column, and
+        (paired with format_mitre_cell) fill the cells — not show a blank one."""
+        threats = [{"Threat Type": "T", "MITRE_ATTACK": "T1190, T1059"}]
+        assert detect_extra_columns(threats).show_mitre is True
+
+    def test_mitre_prose_string_does_not_show_column(self):
+        """A truthy-but-not-a-technique value must not surface a blank column."""
+        threats = [{"Threat Type": "T", "MITRE_ATTACK": "n/a"}]
+        assert detect_extra_columns(threats).show_mitre is False
 
     def test_named_attribute_access(self):
         """The return value exposes positional unpacking AND named attributes
@@ -130,6 +143,14 @@ class TestFormatMitreCell:
     def test_string_form_falls_back_to_id_only(self):
         assert format_mitre_cell(["T1190", "T1078"]) == "T1190, T1078"
 
+    def test_comma_separated_string_recovered(self):
+        """Smaller worker models emit MITRE_ATTACK as one comma-separated
+        string; #134 — it must render instead of leaving the cell blank."""
+        assert format_mitre_cell("T1190, T1059, AML.T0053") == "T1190, T1059, AML.T0053"
+
+    def test_single_id_string(self):
+        assert format_mitre_cell("T1190") == "T1190"
+
     def test_missing_id_skipped(self):
         techs = [{"id": "T1190", "name": "A"}, {"name": "no id"}, {"id": "T1078", "name": "B"}]
         assert format_mitre_cell(techs) == "T1190 (A), T1078 (B)"
@@ -137,11 +158,78 @@ class TestFormatMitreCell:
     def test_empty_or_invalid_yields_empty_string(self):
         assert format_mitre_cell(None) == ""
         assert format_mitre_cell([]) == ""
+        # Prose that isn't a technique ID must not be rendered as a fake one.
         assert format_mitre_cell("not a list") == ""
+        assert format_mitre_cell("see the attached notes for details") == ""
 
     def test_pipes_inside_names_escaped(self):
         techs = [{"id": "T1", "name": "foo | bar"}]
         assert format_mitre_cell(techs) == "T1 (foo \\| bar)"
+
+
+class TestNormalizeMitreTechniques:
+    """The single source of truth every MITRE renderer delegates to (#134)."""
+
+    def test_list_of_objects(self):
+        value = [{"id": "T1190", "name": "Exploit Public-Facing Application"}]
+        assert normalize_mitre_techniques(value) == [
+            ("T1190", "Exploit Public-Facing Application")
+        ]
+
+    def test_list_of_strings(self):
+        assert normalize_mitre_techniques(["T1190", "T1078"]) == [
+            ("T1190", ""),
+            ("T1078", ""),
+        ]
+
+    def test_comma_separated_string(self):
+        assert normalize_mitre_techniques("T1190, T1059, AML.T0053") == [
+            ("T1190", ""),
+            ("T1059", ""),
+            ("AML.T0053", ""),
+        ]
+
+    def test_empty_and_none(self):
+        assert normalize_mitre_techniques(None) == []
+        assert normalize_mitre_techniques("") == []
+        assert normalize_mitre_techniques([]) == []
+        assert normalize_mitre_techniques("   ") == []
+
+    def test_unrecognized_scalar_yields_empty(self):
+        assert normalize_mitre_techniques(123) == []
+        assert normalize_mitre_techniques({"id": "T1190"}) == []  # bare dict, not a list
+
+    def test_string_tokens_filtered_to_ids(self):
+        """Only ID-shaped tokens survive from the string shape, so a prose
+        value never becomes a fake technique."""
+        assert normalize_mitre_techniques("just some prose") == []
+        assert normalize_mitre_techniques("T1190, and some notes, T1078") == [
+            ("T1190", ""),
+            ("T1078", ""),
+        ]
+
+    def test_object_ids_trusted_without_id_filter(self):
+        """Structured objects are authoritative — an unusual id is kept even
+        if it wouldn't pass the string-token ID filter."""
+        assert normalize_mitre_techniques([{"id": "DS0015", "name": "App Log"}]) == [
+            ("DS0015", "App Log")
+        ]
+
+
+class TestIsMitreTechniqueId:
+    def test_enterprise_ids(self):
+        assert is_mitre_technique_id("T1190")
+        assert is_mitre_technique_id("T1078.004")
+
+    def test_atlas_ids(self):
+        assert is_mitre_technique_id("AML.T0053")
+
+    def test_rejects_prose_and_partials(self):
+        assert not is_mitre_technique_id("not an id")
+        assert not is_mitre_technique_id("TA0001")  # tactic, not a technique
+        assert not is_mitre_technique_id("AML.")  # prefix only
+        assert not is_mitre_technique_id("T")
+        assert not is_mitre_technique_id("")
 
 
 class TestMitreUrl:


### PR DESCRIPTION
Closes #134.

## Problem

When a worker model returns `MITRE_ATTACK` as a **comma-separated string** (e.g. `"T1190, T1059, AML.T0053"`) instead of the canonical list shape, the report renderers showed the "MITRE ATT&CK" column but left **every cell blank**, and the SARIF export dropped the technique IDs entirely. The data was present and faithfully preserved in `findings.json` (surfaced by the structured-intermediates work in #122); it was only lost at render time. Smaller/cheaper worker models are the ones most likely to emit the string shape.

## Root cause

Three consumers each accepted **only a `list`** and early-returned on any other shape:
- `format_mitre_cell` (`stride_gpt/core/report_utils.py`) — markdown cell
- `_sarif_mitre_ids` (`stride_gpt/agent/report.py`) — SARIF `properties.mitre_attack`
- `_render_mitre_pills` (`stride_gpt/agent/html_report.py`) — HTML pills *(the same blind spot, not called out in the issue)*

Meanwhile `detect_extra_columns` showed the column on **any truthy value** — so a non-empty string emitted the header while the cells rendered blank.

## Fix

Introduce a single source of truth, `normalize_mitre_techniques(value) -> list[(id, name)]`, in `report_utils.py`, and route all four call sites (the three renderers **and** `detect_extra_columns`) through it so they can never disagree on what counts as populated. It handles:

- canonical list-of-objects `[{"id": "T1190", "name": "..."}]`
- list-of-strings `["T1190", "T1078"]`
- comma-separated string `"T1190, T1059, AML.T0053"`

Tokens parsed out of a **string** are validated against the MITRE/ATLAS ID shape (`is_mitre_technique_id`, sharing the pattern `mitre_url` already used) so a prose value like `"see the attached notes"` is dropped rather than rendered as a fake technique — important for a security report's accuracy. Structured object `id`s stay trusted as-is (an unusual but explicitly-structured id is never second-guessed). Because `detect_extra_columns` now uses the same predicate, the present-but-blank column can't recur for any truthy-but-empty value (a bare int, prose, etc.).

## Tests

- Unit matrix over every shape (list-of-objects, list-of-strings, comma-string, single-id, prose, empty/`None`, non-list scalar) for the normaliser, `format_mitre_cell`, `_sarif_mitre_ids`, and `is_mitre_technique_id`.
- `detect_extra_columns` cases for the string shape (shows) and prose (does not).
- An **end-to-end** test asserting the comma-separated string flows through markdown, SARIF, and HTML together.

Full suite green (452 passed). No new ruff findings versus master on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)