### PR TITLE
feat: add CLI version reporting

### DIFF
--- a/stride_gpt/cli.py
+++ b/stride_gpt/cli.py
@@ -36,6 +36,7 @@ from stride_gpt.config import (
     run_setup,
     show_config,
 )
+from stride_gpt.version import get_version
 
 app = typer.Typer(
     name="stride-gpt",
@@ -44,13 +45,14 @@ app = typer.Typer(
 )
 console = Console()
 
-BANNER = r"""[bold blue]
+BANNER = rf"""[bold blue]
  _____ _____ _____ _____ ____  _____     _____ _____ _____
 |   __|_   _| __  |     |    \|   __|___|   __|  _  |_   _|
 |__   | | | |    -|-   -|  |  |   __|___|  |  |   __| | |
 |_____| |_| |__|__|_____|____/|_____|   |_____|__|    |_|[/bold blue]
 
-[dim]AI-powered threat modeling agent[/dim]"""
+[dim]AI-powered threat modeling agent[/dim]
+[dim]v{get_version()}[/dim]"""
 
 HELP_TEXT = """
 [bold]Commands:[/bold]
@@ -100,8 +102,22 @@ class AppTypeOverride(StrEnum):
 
 
 @app.callback(invoke_without_command=True)
-def interactive(ctx: typer.Context) -> None:
+def interactive(
+    ctx: typer.Context,
+    version: Annotated[
+        bool,
+        typer.Option(
+            "--version",
+            help="Show the installed STRIDE-GPT version and exit.",
+            is_eager=True,
+        ),
+    ] = False,
+) -> None:
     """Launch interactive session if no subcommand is given."""
+    if version:
+        console.print(f"stride-gpt {get_version()}")
+        raise typer.Exit()
+
     if ctx.invoked_subcommand is not None:
         return
 

--- a/stride_gpt/prompt.py
+++ b/stride_gpt/prompt.py
@@ -25,6 +25,7 @@ from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.styles import Style
 
 from stride_gpt.config import CONFIG_DIR
+from stride_gpt.version import get_version
 
 # Slash commands available in the REPL. Order matters for menu display.
 COMMANDS: list[tuple[str, str]] = [
@@ -151,8 +152,10 @@ def build_session(
             )
         else:
             tier_line = f" <b>{worker_provider}</b> / <ansigreen>{worker_model}</ansigreen>"
+        version_text = get_version()
         return HTML(
             f"{tier_line}  "
+            f"<ansicyan>v{version_text}</ansicyan>  "
             f"<ansicyan>cwd:</ansicyan> {cwd}  "
             f"<ansibrightblack>·  Tab to complete  ·  Ctrl+L to clear  ·  /help</ansibrightblack>"
         )

--- a/stride_gpt/version.py
+++ b/stride_gpt/version.py
@@ -1,0 +1,20 @@
+"""Version helpers for STRIDE-GPT."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+PACKAGE_NAME = "stride-gpt"
+
+
+def get_version() -> str:
+    """Return the installed STRIDE-GPT package version.
+
+    Package metadata is the release source of truth. Editable/source-tree runs
+    normally still expose metadata, but keep a readable fallback for unusual
+    environments where the package has not been installed yet.
+    """
+    try:
+        return version(PACKAGE_NAME)
+    except PackageNotFoundError:
+        return "unknown"

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,44 @@
+"""Tests for CLI version reporting."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+
+from typer.testing import CliRunner
+
+from stride_gpt import cli
+from stride_gpt import version as version_module
+
+runner = CliRunner()
+
+
+def test_version_flag_prints_package_version_and_exits(monkeypatch):
+    monkeypatch.setattr(cli, "get_version", lambda: "9.8.7")
+
+    result = runner.invoke(cli.app, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == "stride-gpt 9.8.7"
+
+
+def test_version_flag_skips_config_loading(monkeypatch):
+    monkeypatch.setattr(cli, "get_version", lambda: "9.8.7")
+
+    def fail_if_called():
+        raise AssertionError("config should not load for --version")
+
+    monkeypatch.setattr(cli, "load_config", fail_if_called)
+
+    result = runner.invoke(cli.app, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == "stride-gpt 9.8.7"
+
+
+def test_get_version_falls_back_when_package_metadata_is_missing(monkeypatch):
+    def missing(_: str) -> str:
+        raise PackageNotFoundError
+
+    monkeypatch.setattr(version_module, "version", missing)
+
+    assert version_module.get_version() == "unknown"


### PR DESCRIPTION
## Summary
- add an eager `stride-gpt --version` option that prints package metadata and exits before config/setup flow
- surface the installed version in the startup banner and interactive bottom toolbar
- add focused tests for version output, config short-circuiting, and metadata fallback

Fixes #144

## Validation
- `uv run pytest tests/test_cli_version.py tests/test_cli_helpers.py`
- `uv run ruff check stride_gpt/cli.py stride_gpt/prompt.py stride_gpt/version.py tests/test_cli_version.py`
- `uv run stride-gpt --version`
- `uv run pytest`
