### PR TITLE
Add `--version` flag and show version in the TUI banner (#144)

### DIFF
--- a/stride_gpt/cli.py
+++ b/stride_gpt/cli.py
@@ -6,6 +6,7 @@ import json
 import sys
 from datetime import UTC, datetime
 from enum import StrEnum
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
@@ -95,17 +96,47 @@ class AppTypeOverride(StrEnum):
 
 
 # ---------------------------------------------------------------------------
-# Interactive session
+# Version + interactive session
 # ---------------------------------------------------------------------------
 
 
+def get_version() -> str:
+    """Return the installed package version, read from distribution metadata.
+
+    Falls back to "0.0.0" for source/editable runs where package metadata is
+    absent, so the flag still reports something sane instead of crashing.
+    """
+    try:
+        return version("stride-gpt")
+    except PackageNotFoundError:
+        return "0.0.0"
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"stride-gpt {get_version()}")
+        raise typer.Exit()
+
+
 @app.callback(invoke_without_command=True)
-def interactive(ctx: typer.Context) -> None:
+def interactive(
+    ctx: typer.Context,
+    version: Annotated[
+        bool,
+        typer.Option(
+            "--version",
+            help="Show the installed version and exit.",
+            is_eager=True,
+            callback=_version_callback,
+        ),
+    ] = False,
+) -> None:
     """Launch interactive session if no subcommand is given."""
     if ctx.invoked_subcommand is not None:
         return
 
     console.print(BANNER)
+    console.print(f"[dim]v{get_version()}[/dim]")
 
     # Load or create config
     config = load_config()

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -8,11 +8,16 @@ mocking the config layer.
 
 from __future__ import annotations
 
+import importlib.metadata
+
 import pytest
 import typer
+from typer.testing import CliRunner
 
 from stride_gpt import cli
 from stride_gpt.core.schemas import LLMConfig, ModelPair
+
+runner = CliRunner()
 
 # ---------------------------------------------------------------------------
 # _resolve_provider — pure prefix routing
@@ -154,6 +159,45 @@ class TestCheckTierApiKeys:
     def test_single_tier_skips_architect_check(self):
         models = ModelPair(worker=_cfg())
         assert cli._check_tier_api_keys({}, models) is True
+
+
+# ---------------------------------------------------------------------------
+# Version reporting (issue #144)
+# ---------------------------------------------------------------------------
+
+
+class TestVersion:
+    def test_version_flag_prints_and_exits_zero(self):
+        result = runner.invoke(cli.app, ["--version"])
+        assert result.exit_code == 0
+        assert result.stdout.strip() == f"stride-gpt {cli.get_version()}"
+
+    def test_version_resolves_from_metadata(self):
+        try:
+            # When installed, the reported version must come from distribution
+            # metadata (not a hardcoded constant) and match it exactly.
+            assert cli.get_version() == importlib.metadata.version("stride-gpt")
+        except importlib.metadata.PackageNotFoundError:
+            pytest.skip("stride-gpt distribution not installed")
+
+    def test_banner_shows_version(self, monkeypatch):
+        """The TUI startup banner surfaces the version (issue #144)."""
+        monkeypatch.setattr(
+            cli,
+            "load_config",
+            lambda: {"worker_provider": "OpenAI API", "worker_model": "m"},
+        )
+
+        class _ExitSession:
+            def prompt(self):
+                raise EOFError
+
+        monkeypatch.setattr(
+            "stride_gpt.prompt.build_session", lambda _: _ExitSession()
+        )
+        result = runner.invoke(cli.app, [])
+        assert result.exit_code == 0
+        assert f"v{cli.get_version()}" in result.stdout
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Resolves #144. The CLI previously had no way to report its own version — `stride-gpt --version` errored with `No such option: --version`.

- Added `get_version()` which reads the installed version from distribution metadata via `importlib.metadata.version("stride-gpt")`, with a `PackageNotFoundError` fallback (`0.0.0`) for source/editable runs. The version is **never hardcoded**, so it stays in sync with releases automatically.
- Wired an eager `--version` option into the root Typer callback, so `stride-gpt --version` prints `stride-gpt <version>` and exits 0, short-circuiting before the banner/config flow.
- Surfaced the version in the interactive startup banner (a dim `v<version>` line under the ASCII logo).

The optional REPL status-line (`bottom_toolbar`) change mentioned in the issue was left out to keep this focused; happy to add it as a follow-up if you'd like.

## Acceptance criteria

- [x] `stride-gpt --version` prints `stride-gpt <version>` and exits 0
- [x] Version is read from installed package metadata, not hardcoded
- [x] Version appears in the TUI startup banner

## User-facing changes

- **`stride-gpt --version` now works.** Previously this errored with `No such option: --version`; it now prints `stride-gpt <version>` (e.g. `stride-gpt 0.18.0`) and exits 0. This is the first thing users and bug reports reach for to confirm what's installed.
- **Interactive startup banner shows the version.** A dim `vX.Y.Z` line now appears under the ASCII logo on launch.
- **No breaking changes.** All existing flags, subcommands (`/analyze`, `/quick`, `/reports`), and their help output are unaffected; unknown flags still error as before.

## How tested

- `ruff check .` passes (CI lint gate).
- Added `tests/test_cli_helpers.py::TestVersion`:
  - `--version` prints `stride-gpt <version>` and exits 0
  - version resolves from distribution metadata (skips if not installed)
  - banner output contains the version
- Verified end-to-end: `.venv/Scripts/stride-gpt.exe --version` → `stride-gpt 0.18.0` (exit 0); unknown flags still error (exit 2); subcommand help (`analyze`, `quick`) unaffected.

Full suite: 452 passed. The only 3 failures are pre-existing Windows path-separator assertions in `tests/test_persistence.py`, unrelated to this change (they pass on the Ubuntu CI runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
