### PR TITLE
ci: automate PyPI + Docker Hub release on version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,139 @@
+name: Release
+
+# Fires on version tags (e.g. v0.19.0). One tag drives the whole release:
+# verify the tag matches the packaged version, run the test suite, publish the
+# CLI to PyPI via trusted publishing (OIDC, no token), build and push the
+# multi-arch UI image to Docker Hub, then cut a GitHub Release with generated
+# notes.
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never cancel an in-flight release: a half-published tag is worse than a wait.
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Check tag matches packaged version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          VERSION="$(grep -m1 -E '^version\s*=' pyproject.toml | cut -d'"' -f2)"
+          echo "Tag: $TAG  |  pyproject version: $VERSION"
+          if [ "$TAG" != "$VERSION" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match pyproject version $VERSION. Bump the version and re-tag."
+            exit 1
+          fi
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    needs: verify
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13', '3.14']
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run tests
+        run: uv run pytest
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [verify, test]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/stride-gpt
+    permissions:
+      # Required for PyPI trusted publishing (OIDC). No API token needed.
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: '3.12'
+          enable-cache: true
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  docker:
+    name: Build and push UI image
+    needs: [verify, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Derive image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: mrwadams/stridegpt
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push (amd64 + arm64)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.ui
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  github-release:
+    name: Create GitHub Release
+    needs: [publish-pypi, docker]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,12 @@ When adding a new provider or model, the kwarg shape almost always needs a new b
 - LLM calls are always mocked. The canonical pattern: `@patch("stride_gpt.agent.loop.call_llm_with_tools")` and feed `LLMResponse(content=..., tool_calls=...)`. End-to-end agent-loop tests in `test_loop.py:TestAppTypeFlow` mock multiple turns by setting `side_effect=[turn1, turn2, ...]`.
 - For prompt content tests (`test_variants.py`), assert structural properties (a code is present, a column is rendered) — not exact text. Markdown content changes; structural assertions don't.
 
+## Releasing
+
+- **Releases are automated.** Pushing a `vX.Y.Z` tag triggers `.github/workflows/release.yml`: it verifies the tag matches `pyproject.toml`'s `version`, runs the test matrix, publishes the CLI to PyPI (OIDC trusted publishing, no token), pushes the multi-arch UI image to Docker Hub `mrwadams/stridegpt`, and cuts a GitHub Release. Don't build or publish by hand.
+- The tag must match `pyproject.toml` exactly or the `verify` job fails before anything publishes. See `RELEASING.md` for the cut-a-release steps and the one-time PyPI / Docker Hub credential setup.
+- Every push and PR is gated by `.github/workflows/ci.yml` (ruff + pytest on 3.12/3.13/3.14). Keep it green.
+
 ## A few things to NOT do
 
 - **Don't bypass `core/llm.py`.** It exists to make provider quirks one team's problem.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,70 @@
+# Releasing STRIDE-GPT
+
+Releases are automated by [`.github/workflows/release.yml`](.github/workflows/release.yml).
+Pushing a version tag (`vX.Y.Z`) runs the full pipeline: verify the tag matches
+the packaged version, run the test suite on Python 3.12/3.13/3.14, publish the
+CLI to PyPI, build and push the multi-arch UI image to Docker Hub, then cut a
+GitHub Release with generated notes.
+
+## One-time setup
+
+These configure the credentials the workflow relies on. Do them once.
+
+### PyPI trusted publishing (no token)
+
+The workflow publishes via OIDC, so there is no API token to manage. Add a
+trusted publisher on PyPI instead:
+
+1. Go to the [`stride-gpt` project on PyPI](https://pypi.org/manage/project/stride-gpt/settings/publishing/)
+   → Publishing → Add a new trusted publisher (GitHub).
+2. Fill in:
+   - **Owner**: `mrwadams`
+   - **Repository name**: `stride-gpt`
+   - **Workflow name**: `release.yml`
+   - **Environment name**: `pypi`
+3. In the GitHub repo, create an Environment named `pypi`
+   (Settings → Environments → New environment). Optionally add a required
+   reviewer so a human approves each publish.
+
+### Docker Hub secrets
+
+The UI image publishes to the public `mrwadams/stridegpt` repository (free tier
+covers public pushes). Add two repository secrets under
+Settings → Secrets and variables → Actions:
+
+- `DOCKERHUB_USERNAME` — your Docker Hub username (`mrwadams`).
+- `DOCKERHUB_TOKEN` — a Docker Hub **access token** with Read/Write scope
+  (Account Settings → Personal access tokens → Generate).
+
+## Cutting a release
+
+1. Bump `version` in `pyproject.toml`.
+2. Add the release notes to the top of `README.md` and update any version-pinned
+   references (e.g. `docker pull mrwadams/stridegpt:latest` examples stay
+   correct automatically; the `latest` tag is republished each release).
+3. Commit on `master` (via PR), then tag and push:
+
+   ```bash
+   git checkout master && git pull --ff-only
+   git tag v0.19.0
+   git push origin v0.19.0
+   ```
+
+   The tag must match `pyproject.toml` exactly, or the `verify` job fails before
+   anything is published.
+
+4. Watch the run under the repo's Actions tab. On success:
+   - `stride-gpt X.Y.Z` is live on PyPI (`pip install stride-gpt`).
+   - `mrwadams/stridegpt:X.Y.Z`, `:X.Y`, and `:latest` are pushed (amd64 + arm64).
+   - A GitHub Release for the tag exists with auto-generated notes.
+
+## Notes
+
+- **Concurrency** is set to never cancel an in-flight release; a partially
+  published tag is worse than waiting.
+- **arm64** builds run under QEMU emulation and are slower than amd64. This is
+  expected for the infrequent release cadence.
+- To re-run a failed release, fix the cause and re-push the tag
+  (`git tag -d vX.Y.Z && git push --delete origin vX.Y.Z`, then re-tag). PyPI
+  will reject a re-upload of an already-published version, so bump the version
+  if the PyPI step already succeeded.


### PR DESCRIPTION
## What

Adds `.github/workflows/release.yml` — the release-automation half of opportunity #2 (the CI gate landed in #143). Pushing a `vX.Y.Z` tag now drives the whole release end to end; no more manual `uv build` / `twine` / `docker buildx`.

Pipeline (on `v*.*.*` tags):

1. **verify** — assert the tag matches `pyproject.toml`'s `version`; fail before publishing anything on mismatch.
2. **test** — full pytest suite on Python 3.12 / 3.13 / 3.14 (same matrix as CI), gating everything downstream.
3. **publish-pypi** — `uv build` → `pypa/gh-action-pypi-publish` via OIDC **trusted publishing** (no API token). Scoped to a `pypi` GitHub Environment with `id-token: write`.
4. **docker** — multi-arch (amd64 + arm64) buildx of `Dockerfile.ui`, pushed to **Docker Hub `mrwadams/stridegpt`** tagged `X.Y.Z`, `X.Y`, and `latest`. This is the image home the README consolidated to in v0.17.
5. **github-release** — cut a GitHub Release for the tag with auto-generated notes (fills the gap where v0.16–v0.18 have tags but no Releases).

Concurrency is set to **never cancel** an in-flight release.

## One-time setup required before the first tagged release

Documented in the new `RELEASING.md`:

- **PyPI trusted publisher** on the `stride-gpt` project → owner `mrwadams`, repo `stride-gpt`, workflow `release.yml`, environment `pypi`; and a `pypi` GitHub Environment.
- **Docker Hub secrets** `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` (free — public repo pushes need no paid plan).

## Validation

- `release.yml` parses as valid YAML; job graph verified (`verify → test → {publish-pypi, docker} → github-release`).
- Version-gate logic tested locally against the real `pyproject.toml`: `v0.18.0` matches, `v0.19.0` correctly fails.
- `uv build` confirmed to produce both sdist + wheel for this setuptools project.

Actions pinned to major-version tags, matching the repo's existing workflow convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)