### PR TITLE
feat(cli): add --version flag and show version in TUI banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,12 +380,19 @@ echo "A web API that processes payments..." | stride-gpt quick
 stride-gpt
 ```
 
-Inside the REPL, type `/help` to see available commands and flags.
+Inside the REPL, type `/help` to see available commands and flags. The version is shown under the ASCII banner at startup.
+
+**Check the installed version:**
+
+```bash
+stride-gpt --version    # prints e.g. "stride-gpt 0.18.1" and exits
+```
 
 **Common flags:**
 
 | Flag | Description |
 |------|-------------|
+| `--version` | Print the installed version (`stride-gpt <version>`) and exit |
 | `-o`, `--output` | Save report to a file |
 | `-f`, `--format` | Output format: `markdown` (default), `json`, `sarif`, `html` |
 | `-i`, `--input` | Read the app description from a file (`quick` only) |

--- a/stride_gpt/cli.py
+++ b/stride_gpt/cli.py
@@ -6,6 +6,8 @@ import json
 import sys
 from datetime import UTC, datetime
 from enum import StrEnum
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
@@ -44,13 +46,24 @@ app = typer.Typer(
 )
 console = Console()
 
-BANNER = r"""[bold blue]
+
+def _get_version() -> str:
+    """Return the installed package version, or 'unknown' for source runs."""
+    try:
+        return _pkg_version("stride-gpt")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+__version__ = _get_version()
+
+BANNER = rf"""[bold blue]
  _____ _____ _____ _____ ____  _____     _____ _____ _____
 |   __|_   _| __  |     |    \|   __|___|   __|  _  |_   _|
 |__   | | | |    -|-   -|  |  |   __|___|  |  |   __| | |
 |_____| |_| |__|__|_____|____/|_____|   |_____|__|    |_|[/bold blue]
 
-[dim]AI-powered threat modeling agent[/dim]"""
+[dim]AI-powered threat modeling agent · v{__version__}[/dim]"""
 
 HELP_TEXT = """
 [bold]Commands:[/bold]
@@ -99,8 +112,25 @@ class AppTypeOverride(StrEnum):
 # ---------------------------------------------------------------------------
 
 
+def _version_callback(value: bool) -> None:
+    if value:
+        console.print(f"stride-gpt {__version__}")
+        raise typer.Exit()
+
+
 @app.callback(invoke_without_command=True)
-def interactive(ctx: typer.Context) -> None:
+def interactive(
+    ctx: typer.Context,
+    version: Annotated[
+        bool,
+        typer.Option(
+            "--version",
+            help="Show the version and exit.",
+            callback=_version_callback,
+            is_eager=True,
+        ),
+    ] = False,
+) -> None:
     """Launch interactive session if no subcommand is given."""
     if ctx.invoked_subcommand is not None:
         return

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,43 @@
+"""Tests for `stride-gpt --version` and the version helper.
+
+`--version` is the first thing a bug report reaches for, so its output
+contract (`stride-gpt <version>`, exit 0) is pinned here. The metadata-missing
+fallback is exercised too, since editable/source runs have no package metadata.
+"""
+
+from __future__ import annotations
+
+import re
+from importlib.metadata import PackageNotFoundError
+
+from typer.testing import CliRunner
+
+from stride_gpt import cli
+
+runner = CliRunner()
+
+
+class TestVersionFlag:
+    def test_version_prints_and_exits_zero(self):
+        result = runner.invoke(cli.app, ["--version"])
+        assert result.exit_code == 0
+        assert result.stdout.strip() == f"stride-gpt {cli.__version__}"
+
+    def test_version_output_format(self):
+        """Output is `stride-gpt <version>` with a non-empty version token."""
+        result = runner.invoke(cli.app, ["--version"])
+        match = re.match(r"^stride-gpt (\S+)$", result.stdout.strip())
+        assert match is not None
+        assert match.group(1)
+
+
+class TestGetVersion:
+    def test_returns_installed_version(self):
+        assert cli._get_version() == cli._pkg_version("stride-gpt")
+
+    def test_missing_metadata_falls_back(self, monkeypatch):
+        def _raise(_name):
+            raise PackageNotFoundError
+
+        monkeypatch.setattr(cli, "_pkg_version", _raise)
+        assert cli._get_version() == "unknown"


### PR DESCRIPTION
## Summary

Adds a `stride-gpt --version` flag and surfaces the version in the interactive TUI, as requested in #144.

- **`--version` flag** — eager option on the root Typer callback; prints `stride-gpt <version>` and exits 0, short-circuiting before the banner/config flow so it works as a bare `stride-gpt --version`.
- **Version in the banner** — the startup banner now renders `AI-powered threat modeling agent · v<version>` under the ASCII logo.
- **Single source of truth** — version is read at runtime from installed package metadata (`importlib.metadata.version("stride-gpt")`), with an `"unknown"` fallback for editable/source runs where metadata is absent. Nothing is hardcoded.

The optional REPL bottom-toolbar version was intentionally left out: the version is static, the toolbar is for live session state, and it's already near capacity. The banner + flag cover the "which build am I running / what do I put in a bug report" needs.

## Tests

New `tests/test_cli_version.py` (folds in #149):
- `--version` output contract (`stride-gpt <version>`, exit 0) via Typer's `CliRunner`
- output format regex
- metadata lookup + metadata-missing fallback path

Full suite: 461 passed.

## Docs

README gains a `--version` example, a banner note, and a flags-table row. (#148, the standalone docs issue, is already closed.)

Closes #144
Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)