### PR TITLE
docs: add interactive REPL cheat sheet to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ STRIDE GPT is an AI-powered threat modelling tool that leverages Large Language 
 - [Installation](#installation)
 - [Repository layout](#repository-layout)
 - [Usage](#usage)
+  - [Interactive REPL cheat sheet](#interactive-repl-cheat-sheet)
 - [Sample output](#sample-output)
 - [Security Best Practices](#security-best-practices)
 - [Contributing](#contributing)
@@ -381,7 +382,34 @@ echo "A web API that processes payments..." | stride-gpt quick
 stride-gpt
 ```
 
-Inside the REPL, type `/help` to see available commands and flags. The version is shown under the ASCII banner at startup.
+Inside the REPL, type `/help` to see available commands and flags. The version is shown under the ASCII banner at startup. See the [Interactive REPL cheat sheet](#interactive-repl-cheat-sheet) below for the full command and shortcut reference.
+
+#### Interactive REPL cheat sheet
+
+Launch the REPL with `stride-gpt` (no arguments), then use these commands and shortcuts.
+
+**Commands** — type a slash command at the prompt:
+
+| Command | What it does |
+|---------|--------------|
+| `/analyze [path]` | Analyze a codebase for STRIDE threats (a bare directory path works too) |
+| `/quick` | Quick threat model from a text description |
+| `/reports` | List previous analysis reports (`/reports <n>` views one) |
+| `/config` | View or change settings (model, provider, API keys) |
+| `/help` | Show available commands, flags, and examples |
+| `/quit` | Exit (aliases: `/exit`, `/q`) |
+
+`/analyze`, `/quick`, and `/reports` accept flags: `-o`/`--output <path>`, `-f`/`--format <markdown\|json\|sarif\|html>`, `-y`/`--yes`, and `-i`/`--input <path>` (`/quick`). Type `/help` for the full list.
+
+**Keyboard shortcuts:**
+
+| Key | Action |
+|-----|--------|
+| `Tab` | Complete slash commands and file paths |
+| `↑` / `↓` | Scroll through command history |
+| `→` / `End` | Accept the greyed-out history suggestion |
+| `Ctrl+L` | Clear the screen and scrollback |
+| `Ctrl+C` / `Ctrl+D` | Exit the REPL |
 
 **Check the installed version:**
 


### PR DESCRIPTION
Closes #150.

Adds an **Interactive REPL cheat sheet** subsection under Usage → CLI, plus a nested table-of-contents entry and an inline link from the existing Interactive REPL paragraph.

## What's included
- **Commands** table — `/analyze [path]`, `/quick`, `/reports`, `/config`, `/help`, `/quit` (with `/exit`, `/q` aliases), plus the shared `-o`/`-f`/`-y`/`-i` flags line.
- **Keyboard shortcuts** table — `Tab` (completion), `↑`/`↓` (history), `→`/`End` (accept suggestion), `Ctrl+L` (clear screen + scrollback), `Ctrl+C`/`Ctrl+D` (exit).

## Accuracy
Commands and flags mirror `HELP_TEXT` in `stride_gpt/cli.py`; keyboard shortcuts match `_build_keybindings` in `stride_gpt/prompt.py` and the input loop in `cli.py` (history/auto-suggest come from `PromptSession`).

## Acceptance criteria
- [x] Shortcuts section exists
- [x] Linked from the table of contents

Scope is limited to `README.md` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)