### PR TITLE
chore: gitignore local tooling artifacts (.coverage, .claude/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ doc-review.html
 
 # Test-optimizer report (local only)
 test-optimization.html
+
+# Local tooling artifacts
+.coverage
+.claude/


### PR DESCRIPTION
Ignore local-only tooling artifacts that were showing up as untracked in the repo root:

- `.coverage` — pytest/coverage byproduct.
- `.claude/` — local Claude Code skills and config.

Also normalizes `.gitignore` to LF line endings (it previously had CRLF; no `.gitattributes` enforces CRLF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)