### PR TITLE
chore(ci): bump release.yml actions off deprecated Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: '3.12'
           enable-cache: true
@@ -96,7 +96,7 @@ jobs:
 
       - name: Derive image tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: mrwadams/stridegpt
           tags: |
@@ -105,19 +105,19 @@ jobs:
             type=raw,value=latest
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push (amd64 + arm64)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.ui
@@ -134,6 +134,6 @@ jobs:
       contents: write
     steps:
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true


### PR DESCRIPTION
The first automated release run (v0.19.0) succeeded but flagged **Node 20 deprecation** on several actions pinned in `release.yml` — GitHub is currently force-running them on Node 24 and will eventually drop that fallback. This bumps each to a current major that targets Node 24 natively.

All inputs used by these steps (`python-version`/`enable-cache`, `images`/`tags`, `username`/`password`, `context`/`file`/`platforms`/`push`/`tags`/`labels`, `generate_release_notes`) are unchanged across these majors, so behaviour is identical — a runtime refresh.

## `release.yml`
| Action | From | To |
|---|---|---|
| `astral-sh/setup-uv` | v6 | **v7** |
| `docker/metadata-action` | v5 | v6 |
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/build-push-action` | v6 | v7 |
| `softprops/action-gh-release` | v2 | v3 |

### Note on `setup-uv`
`setup-uv` has **no floating `v8` major tag** (only full versions like `v8.3.2`), so `@v8` fails to resolve — an earlier revision of this PR hit exactly that. `v7.x` already runs on `node24` and keeps a floating `v7` tag, so `@v7` both resolves and clears the deprecation. `ci.yml` was already on `setup-uv@v7` and is left unchanged.

## Verification
- Both workflows parse as valid YAML.
- All target tags confirmed to resolve (`@v7`, `@v6`, `@v4`, `@v7`, `@v3` all exist as floating majors).
- `release.yml` only runs on tag push, so its first exercise is the next release; changes are version-only with unchanged inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)