### PR TITLE
fix: derive SARIF driver version from package metadata

### DIFF
--- a/stride_gpt/agent/report.py
+++ b/stride_gpt/agent/report.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import re
 from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _package_version
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +17,15 @@ from stride_gpt.core.report_utils import (
     threat_table_row,
 )
 from stride_gpt.core.schemas import AnalysisReport, ModelPair, ThreatModelOutput
+
+
+def _get_stride_gpt_version() -> str:
+    """Return the installed STRIDE-GPT version, or ``"unknown"`` for source runs."""
+
+    try:
+        return _package_version("stride-gpt")
+    except PackageNotFoundError:
+        return "unknown"
 
 
 def render_markdown(report: AnalysisReport) -> str:
@@ -287,7 +298,7 @@ def render_sarif(report: AnalysisReport) -> dict[str, Any]:
                     "driver": {
                         "name": "STRIDE-GPT",
                         "informationUri": "https://github.com/mrwadams/stride-gpt",
-                        "version": "0.16.1",
+                        "version": _get_stride_gpt_version(),
                         "rules": rules,
                     }
                 },
@@ -691,7 +702,7 @@ def render_sarif_from_json(data: dict[str, Any]) -> dict[str, Any]:
                 "driver": {
                     "name": "STRIDE-GPT",
                     "informationUri": "https://github.com/mrwadams/stride-gpt",
-                    "version": "0.16.1",
+                    "version": _get_stride_gpt_version(),
                     "rules": rules,
                 }
             },

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -111,6 +111,14 @@ class TestRenderSarif:
         # 2 subsystem threats + 1 cross-cutting
         assert len(results) == 3
 
+    def test_sarif_driver_version_is_configurable(self, monkeypatch, sample_report: AnalysisReport):
+        monkeypatch.setattr(
+            "stride_gpt.agent.report._get_stride_gpt_version",
+            lambda: "9.9.9",
+        )
+        sarif = render_sarif(sample_report)
+        assert sarif["runs"][0]["tool"]["driver"]["version"] == "9.9.9"
+
     def test_sarif_locations(self, sample_report: AnalysisReport):
         sarif = render_sarif(sample_report)
         results = sarif["runs"][0]["results"]
@@ -143,6 +151,17 @@ class TestFromJsonRenderers:
         sarif = render_sarif_from_json(data)
         assert sarif["version"] == "2.1.0"
         assert len(sarif["runs"][0]["results"]) == 3
+
+    def test_sarif_from_json_driver_version_is_configurable(
+        self, monkeypatch, sample_report: AnalysisReport
+    ):
+        monkeypatch.setattr(
+            "stride_gpt.agent.report._get_stride_gpt_version",
+            lambda: "7.7.7",
+        )
+        data = render_json(sample_report)
+        sarif = render_sarif_from_json(data)
+        assert sarif["runs"][0]["tool"]["driver"]["version"] == "7.7.7"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replace hard-coded SARIF driver version (`0.16.1`) in both SARIF render paths with the actual installed STRIDE-GPT package version.

## Why

- Prevents stale metadata in SARIF outputs after releases
- Keeps exported SARIF aligned with the running software version
- Improves compatibility with existing report consumers that surface tool version

## Changes

- Added internal helper ` _get_stride_gpt_version()` in `stride_gpt/agent/report.py`
  - reads `importlib.metadata.version('stride-gpt')`
  - falls back to `"unknown"` when package metadata is unavailable
- Updated `render_sarif()` and `render_sarif_from_json()` to use that helper for `runs[0].tool.driver.version`.
- Added regression tests:
  - `tests/test_report.py::TestRenderSarif::test_sarif_driver_version_is_configurable`
  - `tests/test_report.py::TestFromJsonRenderers::test_sarif_from_json_driver_version_is_configurable`

## Validation

- `uv run pytest tests/test_report.py -k sarif`
- `uv run pytest`
- `uv run ruff check stride_gpt/agent/report.py tests/test_report.py`
