### PR TITLE
fix(lint): reorder None to end of union in _ask_architect return type

### DIFF
--- a/stride_gpt/config.py
+++ b/stride_gpt/config.py
@@ -437,7 +437,7 @@ def run_setup(console: Console, existing: dict[str, Any] | None = None) -> dict[
 
 def _ask_architect(
     console: Console, existing: dict[str, Any] | None
-) -> dict[str, Any] | None | bool:
+) -> dict[str, Any] | bool | None:
     """Branch on whether the user already has an architect tier saved.
 
     Returns:


### PR DESCRIPTION
ruff 0.16.1 enforces `RUF036` (`None` not at the end of the type union). Since `pyproject.toml` selects the whole `RUF` group, the pending Dependabot bump (#172, ruff 0.15.22 → 0.16.1) fails the `Lint (ruff)` job on the single violation below.

```
stride_gpt/config.py:440:6: RUF036 `None` not at the end of the type union
```

Reorders the `_ask_architect` return annotation from `dict[str, Any] | None | bool` to `dict[str, Any] | bool | None`. Cosmetic only — no behaviour change.

Verified locally: `ruff check` passes clean under both 0.15.22 and 0.16.1, and the full suite passes (463 passed).

Merging this unblocks #172, which then just needs a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)