### PR TITLE
fix(quality): clear the remaining 18 CodeQL findings

### DIFF
--- a/apps/web/main.py
+++ b/apps/web/main.py
@@ -1044,7 +1044,9 @@ with st.sidebar:
 
         # Anthropic-specific: Extended Thinking checkbox
         if model_provider == "Anthropic API":
-            use_thinking = st.checkbox(
+            # Not assigned: `key` writes to st.session_state, which is where
+            # the value is read back from further down.
+            st.checkbox(
                 "Enable Extended Thinking",
                 value=st.session_state.get("use_thinking", False),
                 key="use_thinking",
@@ -1734,9 +1736,9 @@ vulnerabilities and prioritising mitigation efforts.
 
                     with col2:
                         # Add a button to allow the user to open the Mermaid Live editor
-                        mermaid_live_button = st.link_button(
-                            "Open Mermaid Live", "https://mermaid.live"
-                        )
+                        # Not assigned: a link button has no return value
+                        # worth reading, it just renders.
+                        st.link_button("Open Mermaid Live", "https://mermaid.live")
 
                     with col3:
                         # Blank placeholder

--- a/stride_gpt/agent/context.py
+++ b/stride_gpt/agent/context.py
@@ -163,5 +163,8 @@ def _query_lm_studio_context(api_base: str, model_name: str) -> int | None:
             if loaded_ctx > 0:
                 return loaded_ctx
     except (httpx.HTTPError, KeyError, TypeError, ValueError):
+        # Best-effort probe of the optional LM Studio server. If it is down or
+        # the response shape is unfamiliar, the context length is simply
+        # unknown, which is the None below, and callers fall back to a default.
         pass
     return None

--- a/stride_gpt/agent/progress.py
+++ b/stride_gpt/agent/progress.py
@@ -18,35 +18,27 @@ class ProgressCallback(Protocol):
 
     def phase_start(self, phase: str, description: str) -> None:
         """A new analysis phase is starting (Planning, Analyzing, Synthesizing)."""
-        ...
 
     def status(self, message: str) -> None:
         """Transient status update (e.g. 'Thinking about Auth...')."""
-        ...
 
     def subsystem_start(self, index: int, total: int, name: str, description: str) -> None:
         """Starting analysis of a subsystem."""
-        ...
 
     def subsystem_done(self, name: str, threat_count: int) -> None:
         """Finished analyzing a subsystem."""
-        ...
 
     def tool_call(self, name: str, args_brief: str, cached: bool) -> None:
         """A tool was called during exploration."""
-        ...
 
     def error(self, name: str, reason: str) -> None:
         """An error occurred analyzing a subsystem."""
-        ...
 
     def limit_reached(self, kind: str, current: int, maximum: int) -> None:
         """A hard limit (LLM calls or tool calls) was reached."""
-        ...
 
     def synthesis_done(self, count: int) -> None:
         """Cross-cutting threat synthesis completed."""
-        ...
 
     def token_budget(self, model: str, limit: int, source: str) -> None:
         """Report the context token budget for the model.
@@ -54,15 +46,12 @@ class ProgressCallback(Protocol):
         Args:
             source: One of "queried", "inferred", "explicit".
         """
-        ...
 
     def no_tool_use_warning(self, subsystem: str) -> None:
         """Warn that a subsystem was analyzed without any tool calls."""
-        ...
 
     def complete(self, summary: str) -> None:
         """Analysis finished. Summary is a human-readable status line."""
-        ...
 
 
 class RichProgress:

--- a/stride_gpt/config.py
+++ b/stride_gpt/config.py
@@ -61,6 +61,9 @@ def fetch_local_models(provider_name: str, api_base: str) -> list[str]:
             resp.raise_for_status()
             return [m["id"] for m in resp.json().get("data", [])]
     except (httpx.HTTPError, KeyError, TypeError):
+        # Probing LM Studio is best-effort: the server is optional and may be
+        # down, unreachable, or serving a payload we do not recognise. Any of
+        # those means "no models to offer", which is the empty list below.
         pass
     return []
 
@@ -132,6 +135,9 @@ def check_lm_studio_context(
                 )
             return False
     except (httpx.HTTPError, KeyError, TypeError, ValueError):
+        # Same best-effort probe as above. A failure here means we could not
+        # read the loaded context length, not that it is too small, so the
+        # check declines to block and returns True below.
         pass
     return True  # Can't check — proceed optimistically
 

--- a/stride_gpt/core/llm.py
+++ b/stride_gpt/core/llm.py
@@ -7,6 +7,7 @@ import re
 
 import litellm
 
+from stride_gpt.core.mermaid_utils import extract_mermaid_code
 from stride_gpt.core.schemas import LLMConfig, LLMResponse, ToolCallResult
 from stride_gpt.models import (
     get_litellm_prefix,
@@ -349,8 +350,6 @@ def process_groq_response(
         except _json.JSONDecodeError:
             processed_output = final_output
     elif "graph " in final_output:
-        from stride_gpt.core.attack_tree import extract_mermaid_code
-
         processed_output = extract_mermaid_code(final_output)
     else:
         processed_output = final_output


### PR DESCRIPTION
All 18 were code-quality queries from the security-and-quality suite, none
with a security severity. Each has a real fix; none needed dismissing.

py/ineffectual-statement x11 -- stride_gpt/agent/progress.py

Every ProgressCallback method is a docstring followed by `...`. The docstring
is already a valid body, so the ellipsis is dead. Removed. Protocol semantics
are unchanged: runtime_checkable only checks method presence, and a
docstring-only body returns None exactly as `...` did.

py/cyclic-import x2 -- core/llm.py, core/attack_tree.py

llm.py deferred `from stride_gpt.core.attack_tree import extract_mermaid_code`
into the function body to dodge the cycle with attack_tree.py's top-level
import of call_llm. But extract_mermaid_code is defined in
core/mermaid_utils.py; attack_tree only re-exports it, and importing it from
there is what created the cycle. Now imported from mermaid_utils at the top of
the file with the other imports. mermaid_utils imports nothing from the
package, so no new cycle. Clears both ends.

py/empty-except x3 -- config.py:63, config.py:134, agent/context.py:165

All three wrap optional LM Studio probes and already have a deliberate
fallback on the next line (`return []`, `return True  # proceed
optimistically`, `return None`). The query fires because there is no
explanatory comment, so each now says why swallowing is correct. No behaviour
change.

py/unused-global-variable x2 -- apps/web/main.py

Same pattern as the selected_model pair in #176. `use_thinking` carries
`key="use_thinking"`, so the value is read back via st.session_state at lines
1596 and 2191; the local was never read. `st.link_button` renders and its
return value is never used. Both assignments dropped.

ruff clean, 463 tests pass. `ruff format --check` reports the same four files
with the same hunks before and after this change, so no new formatting drift.
The alerts close once CodeQL runs on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)