### PR TITLE
fix(planner): represent every directory in the key-file budget

### DIFF
--- a/stride_gpt/agent/planner.py
+++ b/stride_gpt/agent/planner.py
@@ -61,6 +61,32 @@ Be specific about which files to examine. Prioritize subsystems that handle:
 5. Infrastructure and deployment"""
 
 
+def _diverse_key_files(files: list[str], limit: int) -> list[str]:
+    """Cap ``files`` at ``limit`` while representing every directory.
+
+    A flat alphabetical slice privileges early-sorting directories and can
+    drop a whole subsystem's files past the cutoff (issue #175: on OWASP
+    crAPI, ``services/web`` and ``services/workshop`` sorted last and
+    received zero file-level signal). Round-robin across each file's
+    containing directory instead, so every directory contributes before any
+    directory repeats.
+    """
+    if len(files) <= limit:
+        return files
+    queues: dict[str, list[str]] = {}
+    for f in files:
+        queues.setdefault(str(Path(f).parent), []).append(f)
+    ordered = [queues[d] for d in sorted(queues)]
+    sample: list[str] = []
+    while len(sample) < limit and any(ordered):
+        for queue in ordered:
+            if queue:
+                sample.append(queue.pop(0))
+                if len(sample) >= limit:
+                    break
+    return sorted(sample)
+
+
 def create_plan(config: LLMConfig, target_path: Path) -> AnalysisPlan:
     """Scan a codebase and generate an analysis plan via LLM."""
     # Gather codebase structure
@@ -72,6 +98,7 @@ def create_plan(config: LLMConfig, target_path: Path) -> AnalysisPlan:
 
     # Deduplicate and sort
     key_files = sorted(set(key_files))
+    key_files_shown = _diverse_key_files(key_files, 200)
 
     discovery_prompt = f"""Analyze this codebase structure and identify subsystems for STRIDE threat modeling.
 
@@ -79,7 +106,7 @@ def create_plan(config: LLMConfig, target_path: Path) -> AnalysisPlan:
 {dir_listing}
 
 ## Key Files Found ({len(key_files)} files)
-{chr(10).join(key_files[:200])}"""
+{chr(10).join(key_files_shown)}"""
 
     json_config = config.model_copy(update={"response_format": AnalysisPlan.model_json_schema()})
     messages = [

--- a/stride_gpt/agent/planner.py
+++ b/stride_gpt/agent/planner.py
@@ -61,6 +61,18 @@ Be specific about which files to examine. Prioritize subsystems that handle:
 5. Infrastructure and deployment"""
 
 
+def _round_robin(queues: list[list[str]]) -> list[str]:
+    """Interleave ``queues`` fairly: one item from each non-empty queue per round.
+
+    Consumes ``queues`` in place and returns every item, in round-robin
+    order, with no cutoff; callers that need a cap apply it to the result.
+    """
+    result: list[str] = []
+    while any(queues):
+        result.extend(queue.pop(0) for queue in queues if queue)
+    return result
+
+
 def _diverse_key_files(files: list[str], limit: int) -> list[str]:
     """Cap ``files`` at ``limit`` while representing every directory.
 
@@ -70,20 +82,37 @@ def _diverse_key_files(files: list[str], limit: int) -> list[str]:
     received zero file-level signal). Round-robin across each file's
     containing directory instead, so every directory contributes before any
     directory repeats.
+
+    A single round-robin pass over every leaf directory still starves whole
+    subsystems once there are more leaf directories than ``limit``: the
+    first pass through them consumes the entire budget before a
+    later-sorting subsystem's leaf directories are ever reached (issue
+    #178: 250 nested ``services/web/src/mod*`` directories left the sibling
+    ``services/workshop`` directory with zero files, even though it is a
+    small, shallow subsystem of its own). Group leaf directories by their
+    top-level (first one or two path components) directory first, and
+    round-robin across those groups before round-robining the leaf
+    directories within each one, so a subsystem with many nested
+    directories cannot exhaust the budget before a sibling top-level
+    directory gets its share.
     """
     if len(files) <= limit:
         return files
-    queues: dict[str, list[str]] = {}
+
+    leaf_queues: dict[str, list[str]] = {}
     for f in files:
-        queues.setdefault(str(Path(f).parent), []).append(f)
-    ordered = [queues[d] for d in sorted(queues)]
-    sample: list[str] = []
-    while len(sample) < limit and any(ordered):
-        for queue in ordered:
-            if queue:
-                sample.append(queue.pop(0))
-                if len(sample) >= limit:
-                    break
+        leaf_queues.setdefault(str(Path(f).parent), []).append(f)
+
+    top_groups: dict[str, list[list[str]]] = {}
+    for d in sorted(leaf_queues):
+        parts = Path(d).parts
+        top = "/".join(parts[:2]) if len(parts) >= 2 else (parts[0] if parts else d)
+        top_groups.setdefault(top, []).append(leaf_queues[d])
+
+    # Flatten each top-level group into its own fair leaf-directory
+    # ordering first, then round-robin across the (far fewer) groups.
+    group_queues = [_round_robin(top_groups[t]) for t in sorted(top_groups)]
+    sample = _round_robin(group_queues)[:limit]
     return sorted(sample)
 
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from stride_gpt.agent.planner import (
     _build_plan,
+    _diverse_key_files,
     create_plan,
 )
 from stride_gpt.core.schemas import LLMResponse
@@ -113,3 +114,52 @@ class TestCreatePlanRetry:
         assert plan.subsystems[0].name == "Full Codebase"
         assert "not json" in plan.overall_description
         assert mock_call_llm.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# _diverse_key_files
+# ---------------------------------------------------------------------------
+
+
+class TestDiverseKeyFiles:
+    def test_list_under_limit_is_unchanged(self):
+        files = ["a/one.py", "b/two.py"]
+        assert _diverse_key_files(files, 200) == files
+
+    def test_round_robins_across_directories(self):
+        early = [f"aaa/f{i:03d}.py" for i in range(200)]
+        late = [f"zzz/f{i:03d}.py" for i in range(10)]
+        sample = _diverse_key_files(early + late, 200)
+        assert len(sample) == 200
+        assert set(late).issubset(sample)
+
+
+# ---------------------------------------------------------------------------
+# create_plan key-file coverage (issue #175)
+# ---------------------------------------------------------------------------
+
+
+class TestCreatePlanKeyFileCoverage:
+    @patch("stride_gpt.agent.planner.call_llm")
+    def test_late_sorting_directory_reaches_the_prompt(self, mock_call_llm, llm_config, tmp_path):
+        mock_call_llm.return_value = LLMResponse(
+            content=json.dumps({
+                "overall_description": "Test",
+                "subsystems": [{"name": "App", "description": "Main", "key_files": ["app.py"]}],
+            }),
+            thinking=None, reasoning=None, model="test",
+        )
+        extensions = [".py", ".js", ".ts", ".go", ".rs"]
+        (tmp_path / "service_early").mkdir()
+        for ext in extensions:
+            for i in range(40):
+                (tmp_path / "service_early" / f"f{i:03d}{ext}").write_text("x\n")
+        (tmp_path / "service_late").mkdir()
+        for ext in extensions:
+            for i in range(2):
+                (tmp_path / "service_late" / f"f{i:03d}{ext}").write_text("x\n")
+
+        create_plan(llm_config, tmp_path)
+
+        prompt = mock_call_llm.call_args[0][1][1]["content"]
+        assert "service_late/f000.py" in prompt

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -133,6 +133,20 @@ class TestDiverseKeyFiles:
         assert len(sample) == 200
         assert set(late).issubset(sample)
 
+    def test_round_robins_when_directory_count_exceeds_the_limit(self):
+        # PR #178 review: 250 nested leaf directories under one subsystem
+        # must not starve a sibling subsystem of every file, the same
+        # failure as #175 moved from file granularity to directory
+        # granularity.
+        web = [f"services/web/src/mod{i:03d}/index.js" for i in range(250)]
+        workshop = [f"services/workshop/f{i:03d}.py" for i in range(56)]
+        sample = _diverse_key_files(web + workshop, 200)
+        web_count = sum(1 for f in sample if f.startswith("services/web/"))
+        workshop_count = sum(1 for f in sample if f.startswith("services/workshop/"))
+        assert len(sample) == 200
+        assert web_count == 144
+        assert workshop_count == 56
+
 
 # ---------------------------------------------------------------------------
 # create_plan key-file coverage (issue #175)


### PR DESCRIPTION
## Root cause

`create_plan()` builds the discovery prompt from `key_files[:200]`, a flat slice of the
alphabetically sorted match list. On a repo where one directory's files sort early, that
directory alone can fill the 200-file budget, so every file in a later-sorting directory
is invisible to the single planning LLM call and its subsystem is never proposed. On OWASP
crAPI, `services/community` and `deploy` consumed 152 of the 200 slots and `services/web`
(97 files) plus `services/workshop` (56 files) fell entirely past the cutoff. Nothing
records the gap: `run_summary` still reports `subsystems_planned == subsystems_analyzed`,
so a run that silently skipped two services reads as complete.

## Fix

`_diverse_key_files()` groups the matched files by containing directory and round-robins
across the groups instead of slicing the sorted list, so every directory contributes at
least one file to the prompt before any directory contributes a second. This is the "core
fix" suggested in the issue; I left the two other suggestions (a deeper directory listing,
a truncation warning in `run_summary`) out to keep this change to one concern.

## Verification

- `tests/test_planner.py::TestCreatePlanKeyFileCoverage::test_late_sorting_directory_reaches_the_prompt`
  fails on master (the late-sorting directory's files never reach the LLM prompt) and
  passes on this branch, confirmed both ways in the same container.
- Full suite (466 tests) and `ruff check` pass on Python 3.12 and 3.14.
- Not verified against the actual crAPI repro end to end (that needs a live LLM call);
  the regression test reproduces the file-selection mechanism directly instead.

Fixes #175
