### PR TITLE
fix(security): stop scheduled Gitleaks runs failing on model IDs

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -2,3 +2,17 @@
 99402ef2c8c1e01209cb1bbface09b510e259265:main.py:generic-api-key:615
 6f1548891a5af3905da08781af22402ef34aff8e:main.py:generic-api-key:611
 6f1548891a5af3905da08781af22402ef34aff8e:main.py:generic-api-key:612
+# The historic main.py held a "<Provider> API:<model-id>" -> token-limit map.
+# generic-api-key reads the model id as the secret for a key ending in "API".
+# Scheduled and workflow_dispatch runs scan all history and hit these; push and
+# pull_request runs scan only the event's commits and do not. The map now lives
+# in stride_gpt/models.py in a shape the rule does not match, so this list is
+# closed: no new commit can add to it.
+08033eab872d716e1e7476d00d523bd0bb38543b:main.py:generic-api-key:611
+08033eab872d716e1e7476d00d523bd0bb38543b:main.py:generic-api-key:612
+08033eab872d716e1e7476d00d523bd0bb38543b:main.py:generic-api-key:614
+08033eab872d716e1e7476d00d523bd0bb38543b:main.py:generic-api-key:615
+1d7d3e6b603de0842adc529d067dd424e7105205:main.py:generic-api-key:509
+4493879609cda513397128e47cc62b7b842cd7c8:main.py:generic-api-key:519
+5c994179ad4ac5e7513fd70a6399e6ff0a00d387:main.py:generic-api-key:506
+5c994179ad4ac5e7513fd70a6399e6ff0a00d387:main.py:generic-api-key:508


### PR DESCRIPTION
## Problem

Only the **scheduled** Security Scanning runs fail. Push and PR runs pass, which made it look intermittent.

| Trigger | Scan depth | Result |
|---|---|---|
| `push` / `pull_request` | event's commits only | passing |
| `schedule` / `workflow_dispatch` | full history | failing since at least 2026-08-17 |

The full-history scan hits 8 `generic-api-key` findings, all the same false positive:

```python
"Anthropic API:claude-opus-4-5-20251101": {"default": 64000, "max": 200000},
```

The rule reads the model ID (`claude-opus-4-5-20251101`) as the secret for a key ending in "API". All 8 are in `main.py` commits from March to December 2025.

## Why the existing suppression stopped working

`.gitleaksignore` already carried 4 fingerprints for this exact false positive. They had gone stale.

A fingerprint is `commit:file:rule:line`. The existing entries pin commits `99402ef` and `6f15488`, but later edits to `main.py` moved those lines into new commits, minting fingerprints the old entries no longer match. The suppression decayed rather than never having worked.

## Fix

The 8 current fingerprints, appended to `.gitleaksignore`.

This list is closed. That map now lives in `stride_gpt/models.py` in a shape the rule does not match, and the `main.py` commits are immutable, so no new commit can add to it.

## Verification

Verified against **gitleaks 8.24.3** — the version `gitleaks-action@v3` pins, not the latest release:

- Full history, before: `leaks found: 8`, matching the failing run exactly
- Full history, after: `no leaks found`, exit 0
- Also clean on 8.30.1, so a future action bump does not reintroduce it

Confirmed in CI via `workflow_dispatch` on this branch ([run 33620213675](https://github.com/mrwadams/stride-gpt/actions/runs/33620213675)) — Secret Detection passes. The PR's own run does not exercise this path, since it only scans the PR's commits and would pass regardless.

## Approach not taken

A `[[allowlists]]` entry in `.gitleaks.toml` scoped with `targetRules = ["generic-api-key"]` works on 8.30.1 but is silently inert on the pinned 8.24.3 — it parses without error and has no effect. Fingerprints work on both.

## Not addressed here

- `security-summary` prints `✅` next to every job regardless of outcome. On the failing runs it read `✅ Secret Scanning: failure`.
- The push/PR vs schedule scan-depth split means history regressions only ever surface weekly.