### PR TITLE
fix(ci): make security summary icons follow the job result

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -184,11 +184,29 @@ jobs:
 
     steps:
       - name: Check security scan results
+        env:
+          PYTHON_SECURITY: ${{ needs.python-security.result }}
+          SECRET_SCANNING: ${{ needs.secret-scanning.result }}
+          CODEQL_ANALYSIS: ${{ needs.codeql-analysis.result }}
         run: |
-          echo "## Security Scan Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Python Security: ${{ needs.python-security.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Secret Scanning: ${{ needs.secret-scanning.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "✅ CodeQL Analysis: ${{ needs.codeql-analysis.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "View detailed results in the workflow logs and Security tab." >> $GITHUB_STEP_SUMMARY
+          # The icon has to follow the result. Hardcoding ✅ made a failed scan
+          # read as "✅ Secret Scanning: failure", which is how weekly Gitleaks
+          # failures went unnoticed.
+          icon() {
+            case "$1" in
+              success)   echo "✅" ;;
+              failure)   echo "❌" ;;
+              cancelled) echo "⚠️" ;;
+              skipped)   echo "⏭️" ;;
+              *)         echo "❔" ;;
+            esac
+          }
+          {
+            echo "## Security Scan Summary"
+            echo ""
+            echo "$(icon "$PYTHON_SECURITY") Python Security: $PYTHON_SECURITY"
+            echo "$(icon "$SECRET_SCANNING") Secret Scanning: $SECRET_SCANNING"
+            echo "$(icon "$CODEQL_ANALYSIS") CodeQL Analysis: $CODEQL_ANALYSIS"
+            echo ""
+            echo "View detailed results in the workflow logs and Security tab."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

`security-summary` hardcoded `✅` on every line, then printed the real result next to it. A failed job rendered as:

```
✅ Secret Scanning: failure
```

The weekly Gitleaks failures (#182) looked green at a glance, which is part of why they went unactioned.

## Fix

Map the icon from the result:

| Result | Icon |
|---|---|
| `success` | ✅ |
| `failure` | ❌ |
| `cancelled` | ⚠️ |
| `skipped` | ⏭️ |
| anything else | ❔ |

Job results are passed through `env` rather than interpolated into the script body.

## Verification

Ran the step's script locally against each result state.

Reproducing the run that prompted this:

```
## Security Scan Summary

✅ Python Security: success
❌ Secret Scanning: failure
✅ CodeQL Analysis: success
```

All-green, and the cancelled/skipped/empty cases, render as expected. Workflow YAML parses.

## Not addressed here

`security-summary` still concludes `success` when a job it depends on failed — the run that produced the output above reported the summary job as green. Reporting is fixed; the job's own exit status is unchanged, since that affects branch protection and is a separate call.